### PR TITLE
feat(render): split up render & attaching

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ class ExamplePropertiesProvider {
 ExamplePropertiesProvider.$inject = [ 'propertiesPanel' ];
 ```
 
+
 ## Build and Run
 
 

--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -49,6 +49,7 @@ export default class BpmnPropertiesPanelRenderer {
     });
   }
 
+
   /**
    * Attach the properties panel to a parent node.
    *
@@ -73,15 +74,7 @@ export default class BpmnPropertiesPanelRenderer {
     this._parentNode = container;
 
     // (3) render properties panel to new parent
-    render(
-      <BpmnPropertiesPanel
-        element={ element }
-        injector={ this._injector }
-        getProviders={ this._getProviders.bind(this) }
-        layoutConfig={ this._layoutConfig }
-      />,
-      this._parentNode
-    );
+    this._render(element);
 
     // (4) notify interested parties
     this._eventBus.fire('propertiesPanel.attach');
@@ -128,6 +121,29 @@ export default class BpmnPropertiesPanelRenderer {
 
     return event.providers;
   }
+
+  _render(element) {
+    if (!element || isImplicitRoot(element)) {
+      return;
+    }
+
+    render(
+      <BpmnPropertiesPanel
+        element={ element }
+        injector={ this._injector }
+        getProviders={ this._getProviders.bind(this) }
+        layoutConfig={ this._layoutConfig }
+      />,
+      this._parentNode
+    );
+  }
 }
 
 BpmnPropertiesPanelRenderer.$inject = ['config.propertiesPanel', 'injector', 'eventBus'];
+
+
+// helpers ///////////////////////
+
+function isImplicitRoot(element) {
+  return element && element.id === '__implicitroot';
+}

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -254,6 +254,32 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
+  it('should ensure creating -> no import -> attaching -> import works', async function() {
+
+    // given
+    const diagramXml = require('test/fixtures/simple.bpmn').default;
+
+    const { modeler } = await createModeler(null, {
+      shouldImport: false,
+      propertiesPanel: {}
+    });
+
+    const propertiesPanel = modeler.get('propertiesPanel');
+
+    // when
+    propertiesPanel.attachTo(propertiesContainer);
+
+    // assume
+    expect(domQuery('.bio-properties-panel', propertiesContainer)).to.not.exist;
+
+    // and when
+    await modeler.importXML(diagramXml);
+
+    // then
+    expect(domQuery('.bio-properties-panel', propertiesContainer)).to.exist;
+  });
+
+
   it('#attachTo', async function() {
 
     // given


### PR DESCRIPTION
In order to make scenarios happen where the attaching happens _before_ the first real root element got added, we should split up the concerns of attaching and rendering. 

It should be possible to attach a DOM element to the properties panel without actual rendering (which is for example the case inside the [Camunda Modeler BpmnEditor](https://github.com/camunda/camunda-modeler/blob/develop/client/src/app/tabs/bpmn/BpmnEditor.js#L136))

Related to camunda/camunda-modeler#2347