### PR TITLE
History Cleanup and Tasklist group

### DIFF
--- a/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
+++ b/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
@@ -9,6 +9,7 @@ import {
   CandidateStarterProps,
   FieldInjectionProps,
   HistoryCleanupProps,
+  TasklistProps,
   VersionTagProps
 } from './properties';
 
@@ -394,13 +395,14 @@ function HistoryCleanupGroup(element) {
   return null;
 }
 
-// @TODO: implement, hide with no entries in the meantime
 function TasklistGroup(element) {
   const group = {
     label: 'Tasklist',
     id: 'CamundaPlatform__Tasklist',
     component: Group,
-    entries: []
+    entries: [
+      ...TasklistProps({ element })
+    ]
   };
 
   if (group.entries.length) {

--- a/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
+++ b/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
@@ -8,6 +8,7 @@ import { findIndex } from 'min-dash';
 import {
   CandidateStarterProps,
   FieldInjectionProps,
+  HistoryCleanupProps,
   VersionTagProps
 } from './properties';
 
@@ -72,7 +73,7 @@ export default class CamundaPlatformPropertiesProvider {
       ExternalTaskGroup(element),
       FieldInjectionGroup(element),
       FormGroup(element),
-      HistoryTimeToLiveGroup(element),
+      HistoryCleanupGroup(element),
       InitiatorGroup(element),
       InputOutputGroup(element),
       JobConfigurationGroup(element),
@@ -376,12 +377,14 @@ function FieldInjectionGroup(element) {
 }
 
 // @TODO: implement, hide with no entries in the meantime
-function HistoryTimeToLiveGroup(element) {
+function HistoryCleanupGroup(element) {
   const group = {
-    label: 'History Time To Live',
-    id: 'CamundaPlatform__HistoryTimeToLive',
+    label: 'History Cleanup',
+    id: 'CamundaPlatform__HistoryCleanup',
     component: Group,
-    entries: []
+    entries: [
+      ...HistoryCleanupProps({ element })
+    ]
   };
 
   if (group.entries.length) {

--- a/src/provider/camunda-platform/properties/HistoryCleanupProps.js
+++ b/src/provider/camunda-platform/properties/HistoryCleanupProps.js
@@ -1,0 +1,74 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+
+import {
+  useService
+} from '../../../hooks';
+
+
+export function HistoryCleanupProps(props) {
+  const {
+    element
+  } = props;
+
+  const businessObject = getBusinessObject(element);
+
+  if (!is(element, 'bpmn:Process') &&
+      !(is(element, 'bpmn:Participant') && businessObject.get('processRef'))) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'historyTimeToLive',
+      component: <HistoryTimeToLive element={ element } />,
+      isEdited: textFieldIsEdited
+    },
+  ];
+}
+
+function HistoryTimeToLive(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const process = getProcess(element);
+
+  const getValue = () => {
+    return process.get('camunda:historyTimeToLive') || '';
+  };
+
+  const setValue = (value) => {
+    commandStack.execute('properties-panel.update-businessobject', {
+      element: element,
+      businessObject: process,
+      properties: {
+        'camunda:historyTimeToLive': value
+      }
+    });
+  };
+
+  return TextField({
+    element,
+    id: 'historyTimeToLive',
+    label: translate('Time to live'),
+    getValue,
+    setValue,
+    debounce
+  });
+}
+
+
+// helper //////////////////
+
+function getProcess(element) {
+  return is(element, 'bpmn:Process') ?
+    getBusinessObject(element) :
+    getBusinessObject(element).get('processRef');
+}

--- a/src/provider/camunda-platform/properties/TasklistProps.js
+++ b/src/provider/camunda-platform/properties/TasklistProps.js
@@ -1,0 +1,76 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import Checkbox from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+
+import {
+  useService
+} from '../../../hooks';
+
+
+export function TasklistProps(props) {
+  const {
+    element
+  } = props;
+
+  const businessObject = getBusinessObject(element);
+
+  const isEdited = (node) => {
+    return node && !node.checked;
+  };
+
+  if (!is(element, 'bpmn:Process') &&
+      !(is(element, 'bpmn:Participant') && businessObject.get('processRef'))) {
+    return [];
+  }
+
+  return [
+    {
+      id: 'isStartableInTasklist',
+      component: <Startable element={ element } />,
+      isEdited
+    },
+  ];
+}
+
+function Startable(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack');
+  const translate = useService('translate');
+
+  const process = getProcess(element);
+
+  const getValue = () => {
+    return process.get('camunda:isStartableInTasklist');
+  };
+
+  const setValue = (value) => {
+    commandStack.execute('properties-panel.update-businessobject', {
+      element: element,
+      businessObject: process,
+      properties: {
+        'camunda:isStartableInTasklist': value
+      }
+    });
+  };
+
+  return Checkbox({
+    element,
+    id: 'isStartableInTasklist',
+    label: translate('Startable'),
+    getValue,
+    setValue
+  });
+}
+
+
+// helper //////////////////
+
+function getProcess(element) {
+  return is(element, 'bpmn:Process') ?
+    getBusinessObject(element) :
+    getBusinessObject(element).get('processRef');
+}

--- a/src/provider/camunda-platform/properties/index.js
+++ b/src/provider/camunda-platform/properties/index.js
@@ -1,4 +1,5 @@
 export { CandidateStarterProps } from './CandidateStarterProps';
 export { FieldInjectionProps } from './FieldInjectionProps';
 export { HistoryCleanupProps } from './HistoryCleanupProps';
+export { TasklistProps } from './TasklistProps';
 export { VersionTagProps } from './VersionTagProps';

--- a/src/provider/camunda-platform/properties/index.js
+++ b/src/provider/camunda-platform/properties/index.js
@@ -1,3 +1,4 @@
 export { CandidateStarterProps } from './CandidateStarterProps';
 export { FieldInjectionProps } from './FieldInjectionProps';
+export { HistoryCleanupProps } from './HistoryCleanupProps';
 export { VersionTagProps } from './VersionTagProps';

--- a/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
+++ b/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
@@ -195,6 +195,40 @@ describe('<CamundaPlatformPropertiesProvider>', function() {
         expect(historyGroup).not.to.exist;
       }));
 
+
+      it('should show tasklist group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const process = elementRegistry.get('Process_1');
+
+        await act(() => {
+          selection.select(process);
+        });
+
+        // when
+        const tasklistGroup = getGroup(container, 'CamundaPlatform__Tasklist');
+
+        // then
+        expect(tasklistGroup).to.exist;
+      }));
+
+
+      it('should NOT show history group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const process = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(process);
+        });
+
+        // when
+        const tasklistGroup = getGroup(container, 'CamundaPlatform__Tasklist');
+
+        // then
+        expect(tasklistGroup).not.to.exist;
+      }));
+
     });
 
 
@@ -278,6 +312,40 @@ describe('<CamundaPlatformPropertiesProvider>', function() {
 
         // then
         expect(historyGroup).not.to.exist;
+      }));
+
+
+      it('should show tasklist group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const tasklistGroup = getGroup(container, 'CamundaPlatform__Tasklist');
+
+        // then
+        expect(tasklistGroup).to.exist;
+      }));
+
+
+      it('should NOT show tasklist group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_2');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const tasklistGroup = getGroup(container, 'CamundaPlatform__Tasklist');
+
+        // then
+        expect(tasklistGroup).not.to.exist;
       }));
 
     });

--- a/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
+++ b/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
@@ -161,6 +161,40 @@ describe('<CamundaPlatformPropertiesProvider>', function() {
         }
       }));
 
+
+      it('should show history group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const process = elementRegistry.get('Process_1');
+
+        await act(() => {
+          selection.select(process);
+        });
+
+        // when
+        const historyGroup = getGroup(container, 'CamundaPlatform__HistoryCleanup');
+
+        // then
+        expect(historyGroup).to.exist;
+      }));
+
+
+      it('should NOT show history group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const process = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(process);
+        });
+
+        // when
+        const historyGroup = getGroup(container, 'CamundaPlatform__HistoryCleanup');
+
+        // then
+        expect(historyGroup).not.to.exist;
+      }));
+
     });
 
 
@@ -210,6 +244,40 @@ describe('<CamundaPlatformPropertiesProvider>', function() {
 
         // then
         expect(candidateStarterGroup).not.to.exist;
+      }));
+
+
+      it('should show history group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const historyGroup = getGroup(container, 'CamundaPlatform__HistoryCleanup');
+
+        // then
+        expect(historyGroup).to.exist;
+      }));
+
+
+      it('should NOT show history group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const participant = elementRegistry.get('Participant_2');
+
+        await act(() => {
+          selection.select(participant);
+        });
+
+        // when
+        const historyGroup = getGroup(container, 'CamundaPlatform__HistoryCleanup');
+
+        // then
+        expect(historyGroup).not.to.exist;
       }));
 
     });

--- a/test/spec/provider/camunda-platform/HistoryCleanupProps-collaboration.bpmn
+++ b/test/spec/provider/camunda-platform/HistoryCleanupProps-collaboration.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0k5m23w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+    <bpmn:participant id="Participant_empty" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true" camunda:historyTimeToLive="P5D">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_03wmyns_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="129" y="59" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="192" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_0vvxtpi_di" bpmnElement="Participant_empty" isHorizontal="true">
+        <dc:Bounds x="129" y="370" width="600" height="60" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/camunda-platform/HistoryCleanupProps-process.bpmn
+++ b/test/spec/provider/camunda-platform/HistoryCleanupProps-process.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0k5m23w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_1" isExecutable="true" camunda:historyTimeToLive="P5D">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/camunda-platform/HistoryCleanupProps.spec.js
+++ b/test/spec/provider/camunda-platform/HistoryCleanupProps.spec.js
@@ -1,0 +1,245 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  changeInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import CamundaPlatformPropertiesProvider from 'src/provider/camunda-platform';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda.json';
+
+import processDiagramXML from './HistoryCleanupProps-process.bpmn';
+import collaborationDiagramXML from './HistoryCleanupProps-collaboration.bpmn';
+
+
+describe('provider/camunda-platform - HistoryCleanupProps', function() {
+
+  const testModules = [
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    CamundaPlatformPropertiesProvider,
+    CoreModule,
+    ModelingModule,
+    SelectionModule
+  ];
+
+  const moddleExtensions = {
+    camunda: camundaModdleExtensions
+  };
+
+  let container;
+
+
+  describe('bpmn:Process#camunda:historyTimeToLive', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(bootstrapPropertiesPanel(processDiagramXML, {
+      modules: testModules,
+      moddleExtensions,
+      debounceInput: false
+    }));
+
+
+    it('should NOT display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const historyTimeToLiveInput = domQuery('input[name=historyTimeToLive]', container);
+
+      // then
+      expect(historyTimeToLiveInput).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const historyTimeToLiveInput = domQuery('input[name=historyTimeToLive]', container);
+
+      // then
+      expect(historyTimeToLiveInput.value).to.eql(
+        getBusinessObject(process).get('camunda:historyTimeToLive'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const historyTimeToLiveInput = domQuery('input[name=historyTimeToLive]', container);
+      changeInput(historyTimeToLiveInput, '24');
+
+      // then
+      expect(getBusinessObject(process).get('camunda:historyTimeToLive'))
+        .to.eql('24');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const process = elementRegistry.get('Process_1');
+
+        const originalValue = getBusinessObject(process).get('camunda:historyTimeToLive');
+
+        await act(() => {
+          selection.select(process);
+        });
+        const historyTimeToLiveInput = domQuery('input[name=historyTimeToLive]', container);
+        changeInput(historyTimeToLiveInput, '24');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(historyTimeToLiveInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:Participant#processRef.camunda:historyTimeToLive', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(bootstrapPropertiesPanel(collaborationDiagramXML, {
+      modules: testModules,
+      moddleExtensions,
+      debounceInput: false
+    }));
+
+
+    it('should NOT display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const participant = elementRegistry.get('Participant_empty');
+
+      await act(() => {
+        selection.select(participant);
+      });
+
+      // when
+      const historyTimeToLiveInput = domQuery('input[name=historyTimeToLive]', container);
+
+      // then
+      expect(historyTimeToLiveInput).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const participant = elementRegistry.get('Participant_1');
+
+      await act(() => {
+        selection.select(participant);
+      });
+
+      // when
+      const historyTimeToLiveInput = domQuery('input[name=historyTimeToLive]', container);
+
+      // then
+      expect(historyTimeToLiveInput.value).to.eql(
+        getProcess(participant).get('camunda:historyTimeToLive'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const participant = elementRegistry.get('Participant_1');
+
+      await act(() => {
+        selection.select(participant);
+      });
+
+      // when
+      const historyTimeToLiveInput = domQuery('input[name=historyTimeToLive]', container);
+      changeInput(historyTimeToLiveInput, '24');
+
+      // then
+      expect(getProcess(participant).get('camunda:historyTimeToLive'))
+        .to.eql('24');
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        const originalValue = getProcess(participant).get('camunda:historyTimeToLive');
+
+        await act(() => {
+          selection.select(participant);
+        });
+        const historyTimeToLiveInput = domQuery('input[name=historyTimeToLive]', container);
+        changeInput(historyTimeToLiveInput, '24');
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(historyTimeToLiveInput.value).to.eql(originalValue);
+      })
+    );
+
+  });
+
+});
+
+
+// helper //////////////////
+
+function getProcess(participant) {
+  return getBusinessObject(participant).get('processRef');
+}

--- a/test/spec/provider/camunda-platform/TasklistProps-collaboration.bpmn
+++ b/test/spec/provider/camunda-platform/TasklistProps-collaboration.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0k5m23w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:collaboration id="Collaboration_1">
+    <bpmn:participant id="Participant_1" processRef="Process_1" />
+    <bpmn:participant id="Participant_empty" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_1" isExecutable="true" camunda:isStartableInTasklist="false">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1">
+      <bpmndi:BPMNShape id="Participant_03wmyns_di" bpmnElement="Participant_1" isHorizontal="true">
+        <dc:Bounds x="129" y="59" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="192" y="152" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Participant_0vvxtpi_di" bpmnElement="Participant_empty" isHorizontal="true">
+        <dc:Bounds x="129" y="370" width="600" height="60" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/camunda-platform/TasklistProps-process.bpmn
+++ b/test/spec/provider/camunda-platform/TasklistProps-process.bpmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0k5m23w" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_1" isExecutable="false" camunda:isStartableInTasklist="false">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/camunda-platform/TasklistProps.spec.js
+++ b/test/spec/provider/camunda-platform/TasklistProps.spec.js
@@ -1,0 +1,241 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  clickInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import CamundaPlatformPropertiesProvider from 'src/provider/camunda-platform';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda.json';
+
+import processDiagramXML from './TasklistProps-process.bpmn';
+import collaborationDiagramXML from './TasklistProps-collaboration.bpmn';
+
+
+describe('provider/camunda-platform - TasklistProps', function() {
+
+  const testModules = [
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    CamundaPlatformPropertiesProvider,
+    CoreModule,
+    ModelingModule,
+    SelectionModule
+  ];
+
+  let container;
+
+  const moddleExtensions = {
+    camunda: camundaModdleExtensions
+  };
+
+
+  describe('bpmn:Process#camunda:isStartableInTasklist', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(bootstrapPropertiesPanel(processDiagramXML, {
+      modules: testModules,
+      moddleExtensions
+    }));
+
+
+    it('should NOT display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const startableInput = domQuery('input[name=isStartableInTasklist]', container);
+
+      // then
+      expect(startableInput).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const startableInput = domQuery('input[name=isStartableInTasklist]', container);
+
+      // then
+      expect(startableInput.checked).to.eql(
+        getBusinessObject(process).get('camunda:isStartableInTasklist'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const startableInput = domQuery('input[name=isStartableInTasklist]', container);
+      clickInput(startableInput);
+
+      // then
+      expect(getBusinessObject(process).get('camunda:isStartableInTasklist')).to.be.true;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const process = elementRegistry.get('Process_1');
+
+        const originalValue = getBusinessObject(process).get('camunda:isStartableInTasklist');
+
+        await act(() => {
+          selection.select(process);
+        });
+        const startableInput = domQuery('input[name=isStartableInTasklist]', container);
+        clickInput(startableInput);
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(startableInput.checked).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('bpmn:Participant#processRef.camunda:isStartableInTasklist', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(bootstrapPropertiesPanel(collaborationDiagramXML, {
+      modules: testModules,
+      moddleExtensions
+    }));
+
+
+    it('should NOT display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const participant = elementRegistry.get('Participant_empty');
+
+      await act(() => {
+        selection.select(participant);
+      });
+
+      // when
+      const startableInput = domQuery('input[name=isStartableInTasklist]', container);
+
+      // then
+      expect(startableInput).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const participant = elementRegistry.get('Participant_1');
+
+      await act(() => {
+        selection.select(participant);
+      });
+
+      // when
+      const startableInput = domQuery('input[name=isStartableInTasklist]', container);
+
+      // then
+      expect(startableInput.checked).to.eql(
+        getProcess(participant).get('camunda:isStartableInTasklist'));
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const participant = elementRegistry.get('Participant_1');
+
+      await act(() => {
+        selection.select(participant);
+      });
+
+      // when
+      const startableInput = domQuery('input[name=isStartableInTasklist]', container);
+      clickInput(startableInput);
+
+      // then
+      expect(getProcess(participant).get('camunda:isStartableInTasklist')).to.be.true;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const participant = elementRegistry.get('Participant_1');
+
+        const originalValue = getProcess(participant).get('camunda:isStartableInTasklist');
+
+        await act(() => {
+          selection.select(participant);
+        });
+        const startableInput = domQuery('input[name=isStartableInTasklist]', container);
+        clickInput(startableInput);
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(startableInput.checked).to.eql(originalValue);
+      })
+    );
+
+  });
+
+});
+
+
+// helper //////////////////
+
+function getProcess(participant) {
+  return getBusinessObject(participant).get('processRef');
+}


### PR DESCRIPTION
Closes #19 
Closes #22

**History Cleanup group**

I changed the label of the group to "History Cleanup". Reason: [It's the context](https://docs.camunda.org/manual/7.15/user-guide/process-engine/history/#history-cleanup) where this property is used + it copes us open to add more properties to this group once the engine supports it.

![image](https://user-images.githubusercontent.com/9433996/125905042-a3c2004f-c11d-4acd-88df-750daf4479fc.png)


**Tasklist group**

Note that the `edited` state only triggers when the checkbox is _not_ checked (since isStartable=true is the default)

![image](https://user-images.githubusercontent.com/9433996/125745426-bd582f39-c1cf-457e-b786-4c4e794837aa.png)

