### PR TITLE
chore: deduplicate dependencies during testing

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -1,5 +1,8 @@
 const path = require('path');
-const { DefinePlugin } = require('webpack');
+const {
+  DefinePlugin,
+  NormalModuleReplacementPlugin
+} = require('webpack');
 
 const basePath = '.';
 
@@ -96,7 +99,30 @@ module.exports = function(karma) {
 
           // @barmac: process.env has to be defined to make @testing-library/preact work
           'process.env': {}
-        })
+        }),
+        new NormalModuleReplacementPlugin(
+          /^preact(\/[^/]+)?$/,
+          function(resource) {
+
+            const replMap = {
+              'preact/hooks': path.resolve('node_modules/preact/hooks/dist/hooks.module.js'),
+              'preact/jsx-runtime': path.resolve('node_modules/preact/jsx-runtime/dist/jsxRuntime.module.js'),
+              'preact': path.resolve('node_modules/preact/dist/preact.module.js')
+            };
+
+            const replacement = replMap[resource.request];
+
+            if (!replacement) {
+              return;
+            }
+
+            resource.request = replacement;
+          }
+        ),
+        new NormalModuleReplacementPlugin(
+          /^preact\/hooks/,
+          path.resolve('node_modules/preact/hooks/dist/hooks.module.js')
+        )
       ],
       resolve: {
         mainFields: [


### PR DESCRIPTION
This allows us to safely link other preact using libraries into this one.

Note that de-duplication happens naturally on install of non-linked dependencies.

Closes https://github.com/bpmn-io/bpmn-properties-panel/issues/27