### PR TITLE
chore(zeebe): move element checks to properties scope

### DIFF
--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -15,16 +15,8 @@ import {
   TimerEventDefinitionProps
 } from './properties';
 
-import {
-  areInputParametersSupported,
-  areOutputParametersSupported
-} from './utils/InputOutputUtil';
-
-import {
-  areHeadersSupported
-} from './utils/HeadersUtil';
-
 const LOW_PRIORITY = 500;
+
 
 function TaskDefinitionGroup(element) {
 
@@ -205,11 +197,15 @@ function getGroups(element) {
     groups.push(multiInstanceGroup);
   }
 
-  if (areInputParametersSupported(element)) {
+  const inputGroup = InputGroup(element);
+
+  if (inputGroup.items) {
     groups.push(InputGroup(element));
   }
 
-  if (areOutputParametersSupported(element)) {
+  const outputGroup = OutputGroup(element);
+
+  if (outputGroup.items) {
     groups.push(OutputGroup(element));
   }
 
@@ -219,7 +215,9 @@ function getGroups(element) {
     groups.push(outputPropagationGroup);
   }
 
-  if (areHeadersSupported(element)) {
+  const headerGroup = HeaderGroup(element);
+
+  if (headerGroup.items) {
     groups.push(HeaderGroup(element));
   }
 

--- a/src/provider/zeebe/properties/HeaderProps.js
+++ b/src/provider/zeebe/properties/HeaderProps.js
@@ -17,6 +17,7 @@ import {
 import Header from './Header';
 
 import {
+  areHeadersSupported,
   getHeaders,
   getTaskHeaders
 } from '../utils/HeadersUtil';
@@ -27,6 +28,11 @@ import {
 
 
 export function HeaderProps(element) {
+
+  if (!areHeadersSupported(element)) {
+    return null;
+  }
+
   const headers = getHeaders(element) || [];
 
   const items = headers.map((header, index) => {

--- a/src/provider/zeebe/properties/InputProps.js
+++ b/src/provider/zeebe/properties/InputProps.js
@@ -17,6 +17,7 @@ import {
 import InputOutputParameter from './InputOutputParameter';
 
 import {
+  areInputParametersSupported,
   createIOMapping,
   getInputParameters,
   getIoMapping
@@ -29,6 +30,11 @@ import {
 
 
 export function InputProps(element) {
+
+  if (!areInputParametersSupported(element)) {
+    return null;
+  }
+
   const inputParameters = getInputParameters(element) || [];
 
   const items = inputParameters.map((parameter, index) => {

--- a/src/provider/zeebe/properties/OutputProps.js
+++ b/src/provider/zeebe/properties/OutputProps.js
@@ -17,6 +17,7 @@ import {
 import InputOutputParameter from './InputOutputParameter';
 
 import {
+  areOutputParametersSupported,
   getOutputParameters,
   getIoMapping,
   createIOMapping
@@ -29,6 +30,11 @@ import {
 
 
 export function OutputProps(element) {
+
+  if (!areOutputParametersSupported(element)) {
+    return null;
+  }
+
   const outputParameters = getOutputParameters(element) || [];
 
   const items = outputParameters.map((parameter, index) => {


### PR DESCRIPTION
Follow up of Hour of Code.

==> Let the property implementors decide for which elements we provide & display properties. The providers are only collecting those. That's a general strategy we want to follow, to avoid confusion about what properties are displayed when.
