### PR TITLE
feat(camundaPropertiesProvider): support asyncContinuationsProps

### DIFF
--- a/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
+++ b/src/provider/camunda-platform/CamundaPlatformPropertiesProvider.js
@@ -6,6 +6,7 @@ import { is } from 'bpmn-js/lib/util/ModelUtil';
 import { findIndex } from 'min-dash';
 
 import {
+  AsynchronousContinuationsProps,
   CandidateStarterProps,
   ExtensionPropertiesProps,
   ExternalTaskPriorityProps,
@@ -67,7 +68,7 @@ export default class CamundaPlatformPropertiesProvider {
   _getGroups(element) {
     const groups = [
       ProcessVariablesGroup(element),
-      AsyncContinuationGroup(element),
+      AsynchronousContinuationsGroup(element),
       CallActivityGroup(element),
       CandidateStarterGroup(element),
       ConditionalGroup(element),
@@ -318,13 +319,14 @@ function MultiInstanceGroup(element) {
   return null;
 }
 
-// @TODO: implement, hide with no entries in the meantime
-function AsyncContinuationGroup(element) {
+function AsynchronousContinuationsGroup(element) {
   const group = {
-    label: 'Async Continuation',
-    id: 'CamundaPlatform__AsyncContinuation',
+    label: 'Asynchronous Continuations',
+    id: 'CamundaPlatform__AsynchronousContinuations',
     component: Group,
-    entries: []
+    entries: [
+      ...AsynchronousContinuationsProps({ element })
+    ]
   };
 
   if (group.entries.length) {

--- a/src/provider/camunda-platform/properties/AsynchronousContinuationsProps.js
+++ b/src/provider/camunda-platform/properties/AsynchronousContinuationsProps.js
@@ -1,0 +1,192 @@
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import Checkbox, {
+  isEdited as checkboxIsEdited
+} from '@bpmn-io/properties-panel/lib/components/entries/Checkbox';
+
+import {
+  useService
+} from '../../../hooks';
+
+
+export function AsynchronousContinuationsProps(props) {
+  const {
+    element
+  } = props;
+
+  const checkboxIsEditedInverted = (node) => {
+    return node && !node.checked;
+  };
+
+  const businessObject = getBusinessObject(element);
+
+  const entries = [];
+
+  if (is(element, 'camunda:AsyncCapable')) {
+    entries.push(
+      {
+        id: 'asynchronousContinuationBefore',
+        component: <AsynchronousContinuationBefore element={ element } />,
+        isEdited: checkboxIsEdited
+      },
+      {
+        id: 'asynchronousContinuationAfter',
+        component: <AsynchronousContinuationAfter element={ element } />,
+        isEdited: checkboxIsEdited
+      }
+    );
+
+    if (isAsyncBefore(businessObject) || isAsyncAfter(businessObject)) {
+      entries.push(
+        {
+          id: 'exclusive',
+          component: <Exclusive element={ element } />,
+          isEdited: checkboxIsEditedInverted
+        }
+      );
+    }
+  }
+
+  return entries;
+}
+
+function AsynchronousContinuationBefore(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack'),
+        translate = useService('translate');
+
+  const businessObject = getBusinessObject(element);
+
+  const getValue = () => {
+    return isAsyncBefore(businessObject);
+  };
+
+  const setValue = (value) => {
+
+    // overwrite the legacy `async` property, we will use the more explicit `asyncBefore`
+    const props = {
+      'camunda:asyncBefore': value,
+      'camunda:async': undefined
+    };
+
+    commandStack.execute('properties-panel.update-businessobject', {
+      element: element,
+      businessObject: businessObject,
+      properties: props
+    });
+
+  };
+
+  return Checkbox({
+    element,
+    id: 'asynchronousContinuationBefore',
+    label: translate('Before'),
+    getValue,
+    setValue
+  });
+}
+
+function AsynchronousContinuationAfter(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack'),
+        translate = useService('translate');
+
+  const businessObject = getBusinessObject(element);
+
+  const getValue = () => {
+    return isAsyncAfter(businessObject);
+  };
+
+  const setValue = (value) => {
+    commandStack.execute('properties-panel.update-businessobject', {
+      element: element,
+      businessObject: businessObject,
+      properties: {
+        'camunda:asyncAfter': value,
+      }
+    });
+  };
+
+  return Checkbox({
+    element,
+    id: 'asynchronousContinuationAfter',
+    label: translate('After'),
+    getValue,
+    setValue
+  });
+}
+
+function Exclusive(props) {
+  const { element } = props;
+
+  const commandStack = useService('commandStack'),
+        translate = useService('translate');
+
+  const businessObject = getBusinessObject(element);
+
+  const getValue = () => {
+    return isExclusive(businessObject);
+  };
+
+  const setValue = (value) => {
+    commandStack.execute('properties-panel.update-businessobject', {
+      element: element,
+      businessObject: businessObject,
+      properties: {
+        'camunda:exclusive': value,
+      }
+    });
+  };
+
+  return Checkbox({
+    element,
+    id: 'exclusive',
+    label: translate('Exclusive'),
+    getValue,
+    setValue
+  });
+}
+
+
+// helper //////////////////
+
+/**
+ * Returns true if the attribute 'camunda:asyncBefore' is set
+ * to true.
+ *
+ * @param  {ModdleElement} bo
+ *
+ * @return {boolean} a boolean value
+ */
+function isAsyncBefore(bo) {
+  return !!(bo.get('camunda:asyncBefore') || bo.get('camunda:async'));
+}
+
+/**
+ * Returns true if the attribute 'camunda:asyncAfter' is set
+ * to true.
+ *
+ * @param  {ModdleElement} bo
+ *
+ * @return {boolean} a boolean value
+ */
+function isAsyncAfter(bo) {
+  return !!bo.get('camunda:asyncAfter');
+}
+
+/**
+ * Returns true if the attribute 'camunda:exclusive' is set
+ * to true.
+ *
+ * @param  {ModdleElement} bo
+ *
+ * @return {boolean} a boolean value
+ */
+function isExclusive(bo) {
+  return !!bo.get('camunda:exclusive');
+}

--- a/src/provider/camunda-platform/properties/index.js
+++ b/src/provider/camunda-platform/properties/index.js
@@ -1,3 +1,4 @@
+export { AsynchronousContinuationsProps } from './AsynchronousContinuationsProps';
 export { CandidateStarterProps } from './CandidateStarterProps';
 export { ExtensionPropertiesProps } from './ExtensionPropertiesProps';
 export { ExternalTaskPriorityProps } from './ExternalTaskPriorityProps';

--- a/test/spec/provider/camunda-platform/AsynchronousContinuationsProps.bpmn
+++ b/test/spec/provider/camunda-platform/AsynchronousContinuationsProps.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0jwfbqx" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" camunda:asyncAfter="true" camunda:exclusive="false" />
+    <bpmn:task id="Task_1" camunda:asyncBefore="true" />
+    <bpmn:startEvent id="StartEvent_1" />
+    <bpmn:startEvent id="StartEvent_2" camunda:async="true" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1vzjjl9_di" bpmnElement="Task_1">
+        <dc:Bounds x="310" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_087j6w5_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="510" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0zc9vdy_di" bpmnElement="StartEvent_2">
+        <dc:Bounds x="179" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/camunda-platform/AsynchronousContinuationsProps.spec.js
+++ b/test/spec/provider/camunda-platform/AsynchronousContinuationsProps.spec.js
@@ -1,0 +1,473 @@
+import TestContainer from 'mocha-test-container-support';
+import { act } from '@testing-library/preact';
+
+import {
+  bootstrapPropertiesPanel,
+  clickInput,
+  inject
+} from 'test/TestHelper';
+
+import {
+  query as domQuery
+} from 'min-dom';
+
+import {
+  getBusinessObject
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CoreModule from 'bpmn-js/lib/core';
+import SelectionModule from 'diagram-js/lib/features/selection';
+import ModelingModule from 'bpmn-js/lib/features/modeling';
+
+import BpmnPropertiesPanel from 'src/render';
+
+import BpmnPropertiesProvider from 'src/provider/bpmn';
+import CamundaPlatformPropertiesProvider from 'src/provider/camunda-platform';
+
+import camundaModdleExtensions from 'camunda-bpmn-moddle/resources/camunda.json';
+
+import processDiagramXML from './AsynchronousContinuationsProps.bpmn';
+
+
+describe('provider/camunda-platform - AsynchronousContinuationsProps', function() {
+
+  const testModules = [
+    BpmnPropertiesPanel,
+    BpmnPropertiesProvider,
+    CamundaPlatformPropertiesProvider,
+    CoreModule,
+    ModelingModule,
+    SelectionModule
+  ];
+
+  const moddleExtensions = {
+    camunda: camundaModdleExtensions
+  };
+
+  let container;
+
+
+  describe('camunda:AsyncCapable#async', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(bootstrapPropertiesPanel(processDiagramXML, {
+      modules: testModules,
+      moddleExtensions,
+      debounceInput: false
+    }));
+
+
+    it('should NOT display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const asyncBeforeCheckbox = domQuery('input[name=asynchronousContinuationBefore]', container);
+
+      // then
+      expect(asyncBeforeCheckbox).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_2');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const asyncBeforeCheckbox = domQuery('input[name=asynchronousContinuationBefore]', container);
+
+      // then
+      expect(asyncBeforeCheckbox.checked).to.be.true;
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_2');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const asyncBeforeCheckbox = domQuery('input[name=asynchronousContinuationBefore]', container);
+      clickInput(asyncBeforeCheckbox);
+
+      // then
+      expect(isAsyncBefore(startEvent)).to.be.false;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_2'),
+              originalValue = isAsyncBefore(startEvent);
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const asyncBeforeCheckbox = domQuery('input[name=asynchronousContinuationBefore]', container);
+        clickInput(asyncBeforeCheckbox);
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(asyncBeforeCheckbox.checked).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('camunda:AsyncCapable#asyncBefore', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(bootstrapPropertiesPanel(processDiagramXML, {
+      modules: testModules,
+      moddleExtensions,
+      debounceInput: false
+    }));
+
+
+    it('should NOT display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const asyncBeforeCheckbox = domQuery('input[name=asynchronousContinuationBefore]', container);
+
+      // then
+      expect(asyncBeforeCheckbox).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const asyncBeforeCheckbox = domQuery('input[name=asynchronousContinuationBefore]', container);
+
+      // then
+      expect(asyncBeforeCheckbox.checked).to.be.false;
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const asyncBeforeCheckbox = domQuery('input[name=asynchronousContinuationBefore]', container);
+      clickInput(asyncBeforeCheckbox);
+
+      // then
+      expect(isAsyncBefore(startEvent)).to.be.true;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_1'),
+              originalValue = isAsyncBefore(startEvent);
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const asyncBeforeCheckbox = domQuery('input[name=asynchronousContinuationBefore]', container);
+        clickInput(asyncBeforeCheckbox);
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(asyncBeforeCheckbox.checked).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('camunda:AsyncCapable#asyncAfter', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(bootstrapPropertiesPanel(processDiagramXML, {
+      modules: testModules,
+      moddleExtensions,
+      debounceInput: false
+    }));
+
+
+    it('should NOT display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const asyncAfterCheckbox = domQuery('input[name=asynchronousContinuationAfter]', container);
+
+      // then
+      expect(asyncAfterCheckbox).to.not.exist;
+    }));
+
+
+    it('should display', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const asyncAfterCheckbox = domQuery('input[name=asynchronousContinuationAfter]', container);
+
+      // then
+      expect(asyncAfterCheckbox.checked).to.be.false;
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const asyncAfterCheckbox = domQuery('input[name=asynchronousContinuationAfter]', container);
+      clickInput(asyncAfterCheckbox);
+
+      // then
+      expect(isAsyncAfter(startEvent)).to.be.true;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent_1'),
+              originalValue = isAsyncAfter(startEvent);
+
+        await act(() => {
+          selection.select(startEvent);
+        });
+
+        const asyncAfterCheckbox = domQuery('input[name=asynchronousContinuationAfter]', container);
+        clickInput(asyncAfterCheckbox);
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(asyncAfterCheckbox.checked).to.eql(originalValue);
+      })
+    );
+
+  });
+
+
+  describe('camunda:AsyncCapable#exclusive', function() {
+
+    beforeEach(function() {
+      container = TestContainer.get(this);
+    });
+
+    beforeEach(bootstrapPropertiesPanel(processDiagramXML, {
+      modules: testModules,
+      moddleExtensions,
+      debounceInput: false
+    }));
+
+
+    it('should NOT display when not supported', inject(async function(elementRegistry, selection) {
+
+      // given
+      const process = elementRegistry.get('Process_1');
+
+      await act(() => {
+        selection.select(process);
+      });
+
+      // when
+      const exclusiveCheckbox = domQuery('input[name=exclusive]', container);
+
+      // then
+      expect(exclusiveCheckbox).to.not.exist;
+    }));
+
+
+    it('should NOT display when not async', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const exclusiveCheckbox = domQuery('input[name=exclusive]', container);
+
+      // then
+      expect(exclusiveCheckbox).to.not.exist;
+    }));
+
+
+
+    it('should display true when undefined', inject(async function(elementRegistry, selection) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      await act(() => {
+        selection.select(task);
+      });
+
+      // when
+      const exclusiveCheckbox = domQuery('input[name=exclusive]', container);
+
+      // then
+      expect(exclusiveCheckbox.checked).to.be.true;
+    }));
+
+
+    it('should display false when explicitly set', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const exclusiveCheckbox = domQuery('input[name=exclusive]', container);
+
+      // then
+      expect(exclusiveCheckbox.checked).to.be.false;
+    }));
+
+
+    it('should update', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const exclusiveCheckbox = domQuery('input[name=exclusive]', container);
+      clickInput(exclusiveCheckbox);
+
+      // then
+      expect(isExclusive(serviceTask)).to.be.true;
+    }));
+
+
+    it('should update on external change',
+      inject(async function(elementRegistry, selection, commandStack) {
+
+        // given
+        const serviceTask = elementRegistry.get('ServiceTask_1'),
+              originalValue = isExclusive(serviceTask);
+
+        await act(() => {
+          selection.select(serviceTask);
+        });
+
+        const exclusiveCheckbox = domQuery('input[name=exclusive]', container);
+        clickInput(exclusiveCheckbox);
+
+        // when
+        await act(() => {
+          commandStack.undo();
+        });
+
+        // then
+        expect(exclusiveCheckbox.checked).to.eql(originalValue);
+      })
+    );
+
+  });
+
+});
+
+
+// helper //////////////////
+
+function isAsyncBefore(element) {
+  const bo = getBusinessObject(element);
+
+  return !!(bo.get('camunda:asyncBefore') || bo.get('camunda:async'));
+}
+
+function isAsyncAfter(element) {
+  const bo = getBusinessObject(element);
+
+  return !!bo.get('camunda:asyncAfter');
+}
+
+function isExclusive(element) {
+  const bo = getBusinessObject(element);
+
+  return !!bo.get('camunda:exclusive');
+}

--- a/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider-Process.bpmn
+++ b/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider-Process.bpmn
@@ -56,7 +56,8 @@
     <bpmn:sendTask id="ExternalTaskSendTask_2" name="Don&#39;t show external task priority" camunda:class="" />
     <bpmn:group id="Group_181txdl" categoryValueRef="CategoryValue_0gchis2" />
     <bpmn:group id="Group_1k1ibga" categoryValueRef="CategoryValue_1nalfj2" />
-    <bpmn:group id="Group_0eca95z" categoryValueRef="CategoryValue_0vucc3u" />
+    <bpmn:group id="Group_1" categoryValueRef="CategoryValue_0vucc3u" />
+    <bpmn:group id="Group_0qji6iz" categoryValueRef="CategoryValue_15hkyp9" />
   </bpmn:process>
   <bpmn:category id="Category_0s6pp9d">
     <bpmn:categoryValue id="CategoryValue_0gchis2" value="Field Injection" />
@@ -66,6 +67,9 @@
   </bpmn:category>
   <bpmn:category id="Category_06qoi1f">
     <bpmn:categoryValue id="CategoryValue_0vucc3u" value="External Task" />
+  </bpmn:category>
+  <bpmn:category id="Category_1ey5310">
+    <bpmn:categoryValue id="CategoryValue_15hkyp9" value="External Task Priority" />
   </bpmn:category>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -170,28 +174,28 @@
       <bpmndi:BPMNShape id="Activity_0m9ncu1_di" bpmnElement="ExternalTaskSendTask_2">
         <dc:Bounds x="1810" y="360" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Group_181txdl_di" bpmnElement="Group_181txdl">
-        <dc:Bounds x="150" y="330" width="510" height="300" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="371" y="337" width="68" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Group_1k1ibga_di" bpmnElement="Group_1k1ibga">
         <dc:Bounds x="700" y="330" width="650" height="300" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="983" y="337" width="87" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Group_0eca95z_di" bpmnElement="Group_0eca95z">
-        <dc:Bounds x="1380" y="330" width="640" height="300" />
+      <bpmndi:BPMNShape id="Group_181txdl_di" bpmnElement="Group_1">
+        <dc:Bounds x="150" y="330" width="510" height="300" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1668" y="337" width="67" height="14" />
+          <dc:Bounds x="371" y="337" width="68" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0o1gki8_di" bpmnElement="JobExecutionTimerBoundaryEvent_1">
         <dc:Bounds x="1212" y="422" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1198" y="465" width="66" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Group_0qji6iz_di" bpmnElement="Group_0qji6iz">
+        <dc:Bounds x="1390" y="330" width="550" height="300" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1632" y="337" width="67" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
+++ b/test/spec/provider/camunda-platform/CamundaPlatformPropertiesProvider.spec.js
@@ -360,6 +360,40 @@ describe('<CamundaPlatformPropertiesProvider>', function() {
         }
       }));
 
+
+      it('should show asynchronous continuations group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const asynchronousContinuationsGroup = getGroup(container, 'CamundaPlatform__AsynchronousContinuations');
+
+        // then
+        expect(asynchronousContinuationsGroup).to.exist;
+      }));
+
+
+      it('should NOT show asynchronous continuations group', inject(async function(elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Group_1');
+
+        await act(() => {
+          selection.select(task);
+        });
+
+        // when
+        const asynchronousContinuationsGroup = getGroup(container, 'CamundaPlatform__AsynchronousContinuations');
+
+        // then
+        expect(asynchronousContinuationsGroup).to.not.exist;
+      }));
+
     });
 
 


### PR DESCRIPTION
closes #38

![Screenshot_20210721_165606](https://user-images.githubusercontent.com/42800119/126510490-6d66d34f-4f8c-4fd1-96b8-e29f8da90525.png)

Note regarding deletion of `retryTimeCycle`:

* In the old implementation this is explicitly done. However, I would prefer to have this as a custom behavior in camunda-bpmn-js, and will hence not include it here. This is then consistent to how we do it with other properties (e.g., look at outputPropagation in zeebe) and also allows to invoke this logic when adjust the properties via e.g., API.
  * https://github.com/camunda/camunda-bpmn-js/issues/30

Note regarding deletion of `exclusive` flag:

* In the old implementation this is explicitly done when `asyncBefore` or `asyncAfter` is removed. However, I would prefer to have this as a custom behavior in camunda-bpmn-js, and will hence not include it here. This is then consistent to how we do it with other properties (e.g., look at outputPropagation in zeebe) and also allows to invoke this logic when adjust the properties via e.g., API.
  * https://github.com/camunda/camunda-bpmn-js/issues/29


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
