### PR TITLE
fix(icons): use correct icon for signal boundary events

### DIFF
--- a/src/icons/index.js
+++ b/src/icons/index.js
@@ -42,7 +42,7 @@ import IntermediateEventCatchNonInterruptingParallelIcon from './bpmn-icon-inter
 import IntermediateEventCatchNonInterruptingSignalIcon from './bpmn-icon-intermediate-event-catch-non-interrupting-signal.svg';
 import IntermediateEventCatchNonInterruptingTimerIcon from './bpmn-icon-intermediate-event-catch-non-interrupting-timer.svg';
 import IntermediateEventCatchParallelMultipleIcon from './bpmn-icon-intermediate-event-catch-parallel-multiple.svg';
-import IntermediateEventCatchSignalIcon from './bpmn-icon-intermediate-event-catch-cancel.svg';
+import IntermediateEventCatchSignalIcon from './bpmn-icon-intermediate-event-catch-signal.svg';
 import IntermediateEventCatchTimerIcon from './bpmn-icon-intermediate-event-catch-timer.svg';
 import IntermediateEventNoneIcon from './bpmn-icon-intermediate-event-none.svg';
 import IntermediateEventThrowCompensationIcon from './bpmn-icon-intermediate-event-throw-compensation.svg';


### PR DESCRIPTION
Closes #72

Simple typo.

![image](https://user-images.githubusercontent.com/9433996/130454442-23936f04-7e83-4575-90ca-e17a0d890177.png)
