### PR TITLE
Update properties panel for Message Throw and End Events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6737,9 +6737,9 @@
       "dev": true
     },
     "zeebe-bpmn-moddle": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.7.0.tgz",
-      "integrity": "sha512-WIO2WZjjqXyvRQEARZOULWlwOqNGC/7s4Ubd1P9e3LxrxJiPIUVByWeW3ke37Fl4LmBYJv4vMHxyxLm8yJHi8A==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-0.8.0.tgz",
+      "integrity": "sha512-1wly1tG5KB3rbF2OeCuubqsosmR9nPkhvwfi1Wq/qqfChCHLvbfZNny4a/fbxKefTCSlRvxJxxAwjPf1KBrUBg==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "sinon-chai": "^3.7.0",
     "sirv-cli": "^1.0.12",
     "webpack": "^5.38.1",
-    "zeebe-bpmn-moddle": "^0.7.0"
+    "zeebe-bpmn-moddle": "^0.8.0"
   },
   "peerDependencies": {
     "bpmn-js": "8.x",

--- a/src/provider/zeebe/ZeebePropertiesProvider.js
+++ b/src/provider/zeebe/ZeebePropertiesProvider.js
@@ -1,10 +1,5 @@
 import Group from '@bpmn-io/properties-panel/lib/components/Group';
 import ListGroup from '@bpmn-io/properties-panel/lib/components/ListGroup';
-import { is } from 'bpmn-js/lib/util/ModelUtil';
-
-import {
-  getMessageEventDefinition
-} from '../bpmn/utils/EventDefinitionUtil';
 
 import {
   ConditionProps,
@@ -19,6 +14,7 @@ import {
   FormProps,
   TimerProps
 } from './properties';
+import { isMessageEndEvent, isMessageThrowEvent } from './utils/ZeebeServiceTaskUtil';
 
 const LOW_PRIORITY = 500;
 
@@ -259,12 +255,4 @@ ZeebePropertiesProvider.$inject = [ 'propertiesPanel' ];
 
 function findGroup(groups, id) {
   return groups.find(g => g.id === id);
-}
-
-function isMessageEndEvent(element) {
-  return is(element, 'bpmn:EndEvent') && !!getMessageEventDefinition(element);
-}
-
-function isMessageThrowEvent(element) {
-  return is(element, 'bpmn:IntermediateThrowEvent') && !!getMessageEventDefinition(element);
 }

--- a/src/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/provider/zeebe/properties/TaskDefinitionProps.js
@@ -1,6 +1,5 @@
 import {
-  getBusinessObject,
-  is
+  getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import TextField, { isEdited as textFieldIsEdited } from '@bpmn-io/properties-panel/lib/components/entries/TextField';
@@ -17,13 +16,17 @@ import {
   useService
 } from '../../../hooks';
 
+import {
+  isZeebeServiceTask
+} from '../utils/ZeebeServiceTaskUtil';
+
 
 export function TaskDefinitionProps(props) {
   const {
     element
   } = props;
 
-  if (!is(element, 'zeebe:ZeebeServiceTask')) {
+  if (!isZeebeServiceTask(element)) {
     return [];
   }
 

--- a/src/provider/zeebe/utils/HeadersUtil.js
+++ b/src/provider/zeebe/utils/HeadersUtil.js
@@ -1,20 +1,15 @@
 import {
-  isAny
-} from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
-
-import {
-  getBusinessObject
+  getBusinessObject,
+  is
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import {
   getExtensionElementsList
 } from './ExtensionElementsUtil';
+import { isZeebeServiceTask } from './ZeebeServiceTaskUtil';
 
 export function areHeadersSupported(element) {
-  return isAny(element, [
-    'zeebe:ZeebeServiceTask',
-    'bpmn:UserTask'
-  ]);
+  return is(element, 'bpmn:UserTask') || isZeebeServiceTask(element);
 }
 
 /**

--- a/src/provider/zeebe/utils/InputOutputUtil.js
+++ b/src/provider/zeebe/utils/InputOutputUtil.js
@@ -13,6 +13,7 @@ import {
 import {
   createElement
 } from '../../../utils/ElementUtil';
+import { isZeebeServiceTask } from './ZeebeServiceTaskUtil';
 
 function getElements(bo, type, prop) {
   const elems = getExtensionElementsList(bo, type);
@@ -63,11 +64,10 @@ export function getOutputParameters(element) {
 
 export function areInputParametersSupported(element) {
   return isAny(element, [
-    'zeebe:ZeebeServiceTask',
     'bpmn:UserTask',
     'bpmn:SubProcess',
     'bpmn:CallActivity'
-  ]);
+  ]) || isZeebeServiceTask(element);
 }
 
 export function areOutputParametersSupported(element) {

--- a/src/provider/zeebe/utils/ZeebeServiceTaskUtil.js
+++ b/src/provider/zeebe/utils/ZeebeServiceTaskUtil.js
@@ -1,0 +1,26 @@
+import {
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import {
+  getMessageEventDefinition
+} from '../../bpmn/utils/EventDefinitionUtil';
+
+
+export function isZeebeServiceTask(element) {
+  if (!is(element, 'zeebe:ZeebeServiceTask')) return false;
+
+  if (is(element, 'bpmn:EndEvent') || is(element, 'bpmn:IntermediateThrowEvent')) {
+    return !!getMessageEventDefinition(element);
+  }
+
+  return true;
+}
+
+export function isMessageEndEvent(element) {
+  return is(element, 'bpmn:EndEvent') && !!getMessageEventDefinition(element);
+}
+
+export function isMessageThrowEvent(element) {
+  return is(element, 'bpmn:IntermediateThrowEvent') && !!getMessageEventDefinition(element);
+}

--- a/test/spec/provider/zeebe/ZeebePropertiesProvider.spec.js
+++ b/test/spec/provider/zeebe/ZeebePropertiesProvider.spec.js
@@ -62,34 +62,45 @@ describe('<ZeebePropertiesProvider>', function() {
     it('should NOT show input group', inject(async function(elementRegistry, selection) {
 
       // given
-      const task = elementRegistry.get('Task_1');
+      const elements = [
+        elementRegistry.get('Task_1'),
+        elementRegistry.get('Event_1')
+      ];
 
-      await act(() => {
-        selection.select(task);
-      });
+      for (const ele of elements) {
+        await act(() => {
+          selection.select(ele);
+        });
 
-      // when
-      const inputGroup = getGroup(container, 'inputs');
+        // when
+        const inputGroup = getGroup(container, 'inputs');
 
-      // then
-      expect(inputGroup).to.not.exist;
+        // then
+        expect(inputGroup).to.not.exist;
+      }
     }));
 
 
     it('should show input group', inject(async function(elementRegistry, selection) {
 
       // given
-      const serviceTask = elementRegistry.get('ServiceTask_1');
+      const elements = [
+        elementRegistry.get('MessageThrow_1'),
+        elementRegistry.get('MessageEnd_1'),
+        elementRegistry.get('ServiceTask_1')
+      ];
 
-      await act(() => {
-        selection.select(serviceTask);
-      });
+      for (const ele of elements) {
+        await act(() => {
+          selection.select(ele);
+        });
 
-      // when
-      const inputGroup = getGroup(container, 'inputs');
+        // when
+        const inputGroup = getGroup(container, 'inputs');
 
-      // then
-      expect(inputGroup).to.exist;
+        // then
+        expect(inputGroup).to.exist;
+      }
     }));
 
 
@@ -147,17 +158,22 @@ describe('<ZeebePropertiesProvider>', function() {
     it('should show output group', inject(async function(elementRegistry, selection) {
 
       // given
-      const serviceTask = elementRegistry.get('ServiceTask_1');
+      const elements = [
+        elementRegistry.get('ServiceTask_1'),
+        elementRegistry.get('Event_1')
+      ];
 
-      await act(() => {
-        selection.select(serviceTask);
-      });
+      for (const ele of elements) {
+        await act(() => {
+          selection.select(ele);
+        });
 
-      // when
-      const outputGroup = getGroup(container, 'outputs');
+        // when
+        const outputGroup = getGroup(container, 'outputs');
 
-      // then
-      expect(outputGroup).to.exist;
+        // then
+        expect(outputGroup).to.exist;
+      }
     }));
 
 
@@ -177,55 +193,88 @@ describe('<ZeebePropertiesProvider>', function() {
       expect(headerGroup).to.not.exist;
     }));
 
-
     it('should show header group', inject(async function(elementRegistry, selection) {
 
       // given
-      const scriptTask = elementRegistry.get('ScriptTask_1');
+      const elements = [
+        elementRegistry.get('MessageThrow_1'),
+        elementRegistry.get('MessageEnd_1'),
+        elementRegistry.get('ScriptTask_1')
+      ];
 
-      await act(() => {
-        selection.select(scriptTask);
-      });
+      for (const ele of elements) {
+        await act(() => {
+          selection.select(ele);
+        });
 
-      // when
-      const headerGroup = getGroup(container, 'headers');
+        // when
+        const headersGroup = getGroup(container, 'headers');
 
-      // then
-      expect(headerGroup).to.exist;
+        // then
+        expect(headersGroup).to.exist;
+      }
     }));
 
 
-    it('should NOT show task definition group', inject(async function(elementRegistry, selection) {
+    it('should not show header group', inject(async function(elementRegistry, selection) {
 
       // given
-      const task = elementRegistry.get('Task_1');
+      const noneEndEvent = elementRegistry.get('Event_1');
 
       await act(() => {
-        selection.select(task);
+        selection.select(noneEndEvent);
       });
 
       // when
-      const taskDefinitionGroup = getGroup(container, 'taskDefinition');
+      const headersGroup = getGroup(container, 'headers');
 
       // then
-      expect(taskDefinitionGroup).to.not.exist;
+      expect(headersGroup).to.not.exist;
     }));
 
 
     it('should show taskDefinition group', inject(async function(elementRegistry, selection) {
 
       // given
-      const serviceTask = elementRegistry.get('ServiceTask_1');
+      const elements = [
+        elementRegistry.get('MessageThrow_1'),
+        elementRegistry.get('MessageEnd_1'),
+        elementRegistry.get('ServiceTask_1')
+      ];
 
-      await act(() => {
-        selection.select(serviceTask);
-      });
+      for (const ele of elements) {
+        await act(() => {
+          selection.select(ele);
+        });
 
-      // when
-      const taskDefinitionGroup = getGroup(container, 'taskDefinition');
+        // when
+        const taskDefinitionGroup = getGroup(container, 'taskDefinition');
 
-      // then
-      expect(taskDefinitionGroup).to.exist;
+        // then
+        expect(taskDefinitionGroup).to.exist;
+      }
+    }));
+
+
+    it('should not show taskDefinition group', inject(async function(elementRegistry, selection) {
+
+      // given
+      const elements = [
+        elementRegistry.get('Event_1'),
+        elementRegistry.get('Task_1')
+      ];
+
+      for (const ele of elements) {
+        await act(() => {
+          selection.select(ele);
+        });
+
+        // when
+        const taskDefinitionGroup = getGroup(container, 'taskDefinition');
+
+        // then
+        expect(taskDefinitionGroup).to.not.exist;
+      }
     }));
 
 


### PR DESCRIPTION
- Updated `zeebe-bpmn-moodle` version to v0.8.0
- Ensured that ZeebeServiceTask properties are not added for None End Event or None Intermediate Throw Event

__Screenshot__
<img width="662" alt="Screenshot 2021-09-22 at 13 54 24" src="https://user-images.githubusercontent.com/25825387/134386304-49747712-5f33-46cb-94d9-f117e720524c.png">

Related to https://github.com/camunda/camunda-modeler/issues/2420