### PR TITLE
feat: handle incompatible properties provider gracefully

### DIFF
--- a/src/render/BpmnPropertiesPanelRenderer.js
+++ b/src/render/BpmnPropertiesPanelRenderer.js
@@ -100,6 +100,14 @@ export default class BpmnPropertiesPanelRenderer {
       priority = DEFAULT_PRIORITY;
     }
 
+    if (typeof provider.getGroups !== 'function') {
+      console.error(
+        'Properties provider does not impement #getGroups(element) API'
+      );
+
+      return;
+    }
+
     this._eventBus.on('propertiesPanel.getProviders', priority, function(event) {
       event.providers.push(provider);
     });

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -104,7 +104,8 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
     }
   }
 
-  ((singleStart && singleStart === 'cloud') ? it.only : it)('should import simple process (cloud)', async function() {
+
+  (singleStart === 'cloud' ? it.only : it)('should import simple process (cloud)', async function() {
 
     // given
     const diagramXml = require('test/fixtures/simple.bpmn').default;
@@ -130,7 +131,7 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
-  ((singleStart && singleStart === 'platform') ? it.only : it)('should import simple process (platform)', async function() {
+  (singleStart === 'platform' ? it.only : it)('should import simple process (platform)', async function() {
 
     // given
     const diagramXml = require('test/fixtures/simple.bpmn').default;
@@ -156,7 +157,7 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
-  ((singleStart && singleStart === 'bpmn') ? it.only : it)('should import simple process (bpmn)', async function() {
+  (singleStart === 'bpmn' ? it.only : it)('should import simple process (bpmn)', async function() {
 
     // given
     const diagramXml = require('test/fixtures/simple.bpmn').default;

--- a/test/spec/BpmnPropertiesPanelRenderer.spec.js
+++ b/test/spec/BpmnPropertiesPanelRenderer.spec.js
@@ -284,6 +284,50 @@ describe('<BpmnPropertiesPanelRenderer>', function() {
   });
 
 
+  describe('providers', function() {
+
+    const diagramXML = require('test/fixtures/simple.bpmn').default;
+
+    function inject(fn) {
+
+      return async function() {
+        const {
+          modeler
+        } = await createModeler(diagramXML, {
+          additionalModules: [
+            BpmnPropertiesPanel,
+            BpmnPropertiesProvider
+          ]
+        });
+
+        await modeler.invoke(fn);
+      };
+    }
+
+
+    it('should ignore incompatible provider', inject(function(propertiesPanel) {
+
+      // assume
+      expect(propertiesPanel._getProviders()).to.have.length(1);
+
+      // given
+      const incompatibleProvider = {
+        getTabs: function() {
+          return [];
+        }
+      };
+
+      // when
+      propertiesPanel.registerProvider(incompatibleProvider);
+
+      // then
+      // incompatible provider was not added
+      expect(propertiesPanel._getProviders()).to.have.length(1);
+    }));
+
+  });
+
+
   describe('integration', function() {
 
     it('should ensure creating + importing -> attaching works', async function() {


### PR DESCRIPTION
Related to https://github.com/bpmn-io/internal-docs/issues/323

----

Testing in the same way we're testing in the old properties panel (https://github.com/bpmn-io/bpmn-js-properties-panel/pull/482) by using the internal `_getProviders` API to assert a incompatible provider is ignored.