### PR TITLE
Add Template Input, Output and Error Properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -378,9 +378,9 @@
       }
     },
     "@bpmn-io/properties-panel": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.6.0.tgz",
-      "integrity": "sha512-e+ZnI9zwyqsF8lEKLnui/jRCu6eOIyMeXiZSIXLAcHuNfxbZv7QpVgQdas56kHyCev0dAkfYy4Fnr9bfy8JTUg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-0.6.1.tgz",
+      "integrity": "sha512-WZ6ITLXHUjQ/WbKueMrXU8jbITjbrr5TTlgVt6mbyPqhzOJhXq+oq6NQCJghDE2ydhgLI0h7FPzbrtp4syynlw==",
       "requires": {
         "classnames": "^2.3.1",
         "min-dash": "^3.7.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@bpmn-io/element-templates-validator": "^0.3.0",
     "@bpmn-io/extract-process-variables": "^0.4.3",
-    "@bpmn-io/properties-panel": "^0.6.0",
+    "@bpmn-io/properties-panel": "^0.6.1",
     "classnames": "^2.3.1",
     "ids": "^1.0.0",
     "min-dash": "^3.8.0",

--- a/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
+++ b/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
@@ -1,6 +1,11 @@
 import ElementTemplatesGroup from './components/ElementTemplatesGroup';
 
-import { CustomProperties } from './properties';
+import {
+  CustomProperties,
+  InputProperties
+} from './properties';
+
+const CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter';
 
 const LOWER_PRIORITY = 300;
 
@@ -27,10 +32,20 @@ export default class ElementTemplatesPropertiesProvider {
         entries: []
       };
 
-      const customPropertiesGroups = CustomProperties({ element, elementTemplates: this._elementTemplates });
-
       // (1) Add templates group
-      addGroupsAfter('documentation', groups, [ templatesGroup, ...customPropertiesGroups ]);
+      addGroupsAfter('documentation', groups, [ templatesGroup ]);
+
+      const elementTemplate = this._elementTemplates.get(element);
+
+      if (elementTemplate) {
+        const customPropertiesGroups = CustomProperties({ element, elementTemplate });
+
+        // (2) add custom properties groups
+        addGroupsAfter('template', groups, [ ...customPropertiesGroups ]);
+
+        // (3) update existing groups with element template specific properties
+        updateInputGroup(groups, element, elementTemplate);
+      }
 
       // @TODO(barmac): add template-specific groups and remove according to entriesVisible
 
@@ -61,4 +76,34 @@ function addGroupsAfter(id, groups, groupsToAdd) {
     // add in the beginning if group with provided id is missing
     groups.unshift(...groupsToAdd);
   }
+}
+
+function updateInputGroup(groups, element, elementTemplate) {
+  const inputGroup = findGroup(groups, 'CamundaPlatform__Input');
+
+  if (!inputGroup) {
+    return;
+  }
+
+  delete inputGroup.add;
+
+  inputGroup.items = [];
+
+  const properties = elementTemplate.properties.filter(({ binding, type }) => {
+    return !type && binding.type === CAMUNDA_INPUT_PARAMETER_TYPE;
+  });
+
+  properties.forEach((property, index) => {
+    const item = InputProperties({ element, index, property });
+
+    if (item) {
+      inputGroup.items.push(item);
+    }
+  });
+}
+
+// helpers //////////
+
+function findGroup(groups, id) {
+  return groups.find((group) => group.id === id);
 }

--- a/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
+++ b/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
@@ -2,10 +2,12 @@ import ElementTemplatesGroup from './components/ElementTemplatesGroup';
 
 import {
   CustomProperties,
-  InputProperties
+  InputProperties,
+  OutputProperties
 } from './properties';
 
-const CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter';
+const CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter',
+      CAMUNDA_OUTPUT_PARAMETER_TYPE = 'camunda:outputParameter';
 
 const LOWER_PRIORITY = 300;
 
@@ -45,6 +47,7 @@ export default class ElementTemplatesPropertiesProvider {
 
         // (3) update existing groups with element template specific properties
         updateInputGroup(groups, element, elementTemplate);
+        updateOutputGroup(groups, element, elementTemplate);
       }
 
       // @TODO(barmac): add template-specific groups and remove according to entriesVisible
@@ -98,6 +101,30 @@ function updateInputGroup(groups, element, elementTemplate) {
 
     if (item) {
       inputGroup.items.push(item);
+    }
+  });
+}
+
+function updateOutputGroup(groups, element, elementTemplate) {
+  const outputGroup = findGroup(groups, 'CamundaPlatform__Output');
+
+  if (!outputGroup) {
+    return;
+  }
+
+  delete outputGroup.add;
+
+  outputGroup.items = [];
+
+  const properties = elementTemplate.properties.filter(({ binding, type }) => {
+    return !type && binding.type === CAMUNDA_OUTPUT_PARAMETER_TYPE;
+  });
+
+  properties.forEach((property, index) => {
+    const item = OutputProperties({ element, index, property });
+
+    if (item) {
+      outputGroup.items.push(item);
     }
   });
 }

--- a/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
+++ b/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
@@ -2,11 +2,13 @@ import ElementTemplatesGroup from './components/ElementTemplatesGroup';
 
 import {
   CustomProperties,
+  ErrorProperties,
   InputProperties,
   OutputProperties
 } from './properties';
 
-const CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter',
+const CAMUNDA_ERROR_EVENT_DEFINITION_TYPE = 'camunda:errorEventDefinition',
+      CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter',
       CAMUNDA_OUTPUT_PARAMETER_TYPE = 'camunda:outputParameter';
 
 const LOWER_PRIORITY = 300;
@@ -48,6 +50,7 @@ export default class ElementTemplatesPropertiesProvider {
         // (3) update existing groups with element template specific properties
         updateInputGroup(groups, element, elementTemplate);
         updateOutputGroup(groups, element, elementTemplate);
+        updateErrorsGroup(groups, element, elementTemplate);
       }
 
       // @TODO(barmac): add template-specific groups and remove according to entriesVisible
@@ -125,6 +128,30 @@ function updateOutputGroup(groups, element, elementTemplate) {
 
     if (item) {
       outputGroup.items.push(item);
+    }
+  });
+}
+
+function updateErrorsGroup(groups, element, elementTemplate) {
+  const errorsGroup = findGroup(groups, 'CamundaPlatform__Errors');
+
+  if (!errorsGroup) {
+    return;
+  }
+
+  delete errorsGroup.add;
+
+  errorsGroup.items = [];
+
+  const properties = elementTemplate.properties.filter(({ binding, type }) => {
+    return !type && binding.type === CAMUNDA_ERROR_EVENT_DEFINITION_TYPE;
+  });
+
+  properties.forEach((property, index) => {
+    const item = ErrorProperties({ element, index, property });
+
+    if (item) {
+      errorsGroup.items.push(item);
     }
   });
 }

--- a/src/provider/element-templates/Helper.js
+++ b/src/provider/element-templates/Helper.js
@@ -156,17 +156,17 @@ export function findOutputParameter(inputOutput, binding) {
   });
 }
 
-export function findCamundaErrorEventDefinition(element, bindingErrorRef) {
+export function findCamundaErrorEventDefinition(element, errorRef) {
   const errorEventDefinitions = findExtensions(element, [ 'camunda:ErrorEventDefinition' ]);
 
   let error;
 
-  // error id has to start with <Error_${binding.errorRef}_>
+  // error ID has to start with <Error_${ errorRef }_>
   return errorEventDefinitions.find((definition) => {
     error = definition.get('bpmn:errorRef');
 
     if (error) {
-      return error.get('bpmn:id').indexOf(`Error_${ bindingErrorRef }`) === 0;
+      return error.get('bpmn:id').startsWith(`Error_${ errorRef }`);
     }
   });
 }

--- a/src/provider/element-templates/properties/CustomProperties.js
+++ b/src/provider/element-templates/properties/CustomProperties.js
@@ -85,16 +85,10 @@ const PRIMITIVE_MODDLE_TYPES = [
 export function CustomProperties(props) {
   const {
     element,
-    elementTemplates
+    elementTemplate
   } = props;
 
   const groups = [];
-
-  const elementTemplate = elementTemplates.get(element);
-
-  if (!elementTemplate) {
-    return groups;
-  }
 
   const {
     id,

--- a/src/provider/element-templates/properties/ErrorProperties.js
+++ b/src/provider/element-templates/properties/ErrorProperties.js
@@ -1,0 +1,96 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+
+import Error from '../../camunda-platform/properties/Error';
+
+import {
+  findCamundaErrorEventDefinition,
+  findExtensions
+} from '../Helper';
+
+import { useService } from '../../../hooks';
+
+
+export function ErrorProperties(props) {
+  const {
+    element,
+    index,
+    property
+  } = props;
+
+  const {
+    binding,
+    label
+  } = property;
+
+  const {
+    errorRef,
+    name
+  } = binding;
+
+  const businessObject = getBusinessObject(element),
+        errorEventDefinitions = findExtensions(businessObject, [ 'camunda:ErrorEventDefinition' ]);
+
+  if (!errorEventDefinitions.length) {
+    return;
+  }
+
+  const errorEventDefinition = findCamundaErrorEventDefinition(element, errorRef);
+
+  const id = `${ element.id }-errorEventDefinition-${ index }`;
+
+  let entries = [];
+
+  entries = Error({
+    idPrefix: id,
+    element,
+    errorEventDefinition
+  });
+
+  // (1) remove global error referenced entry
+  entries.shift();
+
+  // (2) remove throw expression input
+  entries.pop();
+
+  // (3) add disabled throw expression input
+  entries.push({
+    id: `${ id }-expression`,
+    component: <Expression errorEventDefinition={ errorEventDefinition } id={ `${ id }-expression` } property={ property } />
+  });
+
+  const item = {
+    id,
+    label: label || name,
+    entries
+  };
+
+  return item;
+}
+
+function Expression(props) {
+  const {
+    errorEventDefinition,
+    id
+  } = props;
+
+  const translate = useService('translate');
+  const debounce = useService('debounceInput');
+
+  const setValue = () => {};
+
+  const getValue = () => {
+    return errorEventDefinition.get('camunda:expression');
+  };
+
+  return TextField({
+    element: errorEventDefinition,
+    id,
+    label: translate('Throw expression'),
+    getValue,
+    setValue,
+    debounce,
+    disabled: true
+  });
+}

--- a/src/provider/element-templates/properties/ErrorProperties.js
+++ b/src/provider/element-templates/properties/ErrorProperties.js
@@ -1,3 +1,5 @@
+import { without } from 'min-dash';
+
 import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
 
 import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
@@ -49,10 +51,12 @@ export function ErrorProperties(props) {
   });
 
   // (1) remove global error referenced entry
-  entries.shift();
+  // entries.shift();
+  entries = removeEntry(entries, '-errorRef');
 
   // (2) remove throw expression input
-  entries.pop();
+  // entries.pop();
+  entries = removeEntry(entries, '-expression');
 
   // (3) add disabled throw expression input
   entries.push({
@@ -93,4 +97,10 @@ function Expression(props) {
     debounce,
     disabled: true
   });
+}
+
+function removeEntry(entries, suffix) {
+  const entry = entries.find(({ id }) => id.endsWith(suffix));
+
+  return without(entries, entry);
 }

--- a/src/provider/element-templates/properties/InputProperties.js
+++ b/src/provider/element-templates/properties/InputProperties.js
@@ -1,0 +1,219 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import ToggleSwitch from '@bpmn-io/properties-panel/lib/components/entries/ToggleSwitch';
+
+import InputOutputParameter from '../../camunda-platform/properties/InputOutputParameter';
+
+import {
+  findExtension,
+  findInputParameter
+} from '../Helper';
+
+import { useService } from '../../../hooks';
+
+import { without } from 'min-dash';
+
+import { createElement } from '../../../utils/ElementUtil';
+
+import { createInputParameter } from '../CreateHelper';
+
+
+export function InputProperties(props) {
+  const {
+    element,
+    index,
+    property
+  } = props;
+
+  const {
+    binding,
+    description,
+    label
+  } = property;
+
+  const { name } = binding;
+
+  const businessObject = getBusinessObject(element),
+        inputOutput = findExtension(businessObject, 'camunda:InputOutput');
+
+  if (!inputOutput) {
+    return;
+  }
+
+  const inputParameter = findInputParameter(inputOutput, binding);
+
+  const id = `${ element.id }-inputParameter-${ index }`;
+
+  let entries = [];
+
+  if (inputParameter) {
+    entries = InputOutputParameter({
+      idPrefix: id,
+      element,
+      parameter: inputParameter
+    });
+
+    // (1) remove name entry
+    entries.shift();
+  }
+
+  // (2) add local variable assignment entry
+  entries.unshift({
+    id: `${ id }-local-variable-assignment`,
+    component: <LocalVariableAssignment element={ element } id={ `${ id }-local-variable-assignment` } property={ property } />
+  });
+
+  // (3) add description entry
+  if (description) {
+    entries.unshift({
+      id: `${ id }-description`,
+      component: <Description id={ `${ id }-description` } text={ description } />
+    });
+  }
+
+  const item = {
+    id,
+    label: label || name,
+    entries
+  };
+
+  return item;
+}
+
+// TODO(philippfromme): add text entry to properties-panel
+function Description(props) {
+  const {
+    id,
+    text
+  } = props;
+
+  return <div class="bio-properties-panel-entry" data-entry-id={ id }>
+    <div class="bio-properties-panel-description">{ text }</div>
+  </div>;
+}
+
+function LocalVariableAssignment(props) {
+  const {
+    element,
+    id,
+    property
+  } = props;
+
+  const { binding } = property;
+
+  const bpmnFactory = useService('bpmnFactory'),
+        commandStack = useService('commandStack'),
+        translate = useService('translate');
+
+  const businessObject = getBusinessObject(element),
+        inputOutput = findExtension(businessObject, 'camunda:InputOutput');
+
+  const inputParameter = findInputParameter(inputOutput, binding);
+
+  const getValue = () => {
+    return findInputParameter(inputOutput, binding);
+  };
+
+  const setValue = (value) => {
+    if (value) {
+      addInputParameter(element, property, bpmnFactory, commandStack);
+    } else {
+      removeInputParameter(element, binding, commandStack);
+    }
+  };
+
+  return ToggleSwitch({
+    id,
+    label: translate('Local variable assignment'),
+    switcherLabel: inputParameter ?
+      translate('On') :
+      translate('Off'),
+    description: inputParameter ?
+      '' :
+      translate('Parameter won\'t be created as local variable.'),
+    getValue,
+    setValue
+  });
+}
+
+function addInputParameter(element, property, bpmnFactory, commandStack) {
+  const {
+    binding,
+    value
+  } = property;
+
+  const commands = [];
+
+  const businessObject = getBusinessObject(element);
+
+  let extensionElements = businessObject.get('extensionElements');
+
+  // (1) ensure bpmn:ExtensionElements
+  if (!extensionElements) {
+    extensionElements = createElement(
+      'bpmn:ExtensionElements',
+      { values: [] },
+      businessObject,
+      bpmnFactory
+    );
+
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: businessObject,
+        properties: { extensionElements }
+      }
+    });
+  }
+
+  // (2) ensure camunda:InputOutput
+  let inputOutput = findExtension(businessObject, 'camunda:InputOutput');
+
+  if (!inputOutput) {
+    inputOutput = createElement('camunda:InputOutput', {
+      inputParameters: [],
+      outputParameters: []
+    }, extensionElements, bpmnFactory);
+
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: extensionElements,
+        properties: { values: [ ...extensionElements.get('values'), inputOutput ] }
+      }
+    });
+  }
+
+  // (3) add camunda:InputParameter
+  const inputParameter = createInputParameter(binding, value, bpmnFactory);
+
+  inputParameter.$parent = inputOutput;
+
+  commands.push({
+    cmd: 'element.updateModdleProperties',
+    context: {
+      element,
+      moddleElement: inputOutput,
+      properties: { inputParameters: [ ...inputOutput.get('camunda:inputParameters'), inputParameter ] }
+    }
+  });
+
+  commandStack.execute('properties-panel.multi-command-executor', commands);
+}
+
+function removeInputParameter(element, binding, commandStack) {
+  const businessObject = getBusinessObject(element);
+
+  const inputOutput = findExtension(businessObject, 'camunda:InputOutput'),
+        inputParameters = inputOutput.get('camunda:inputParameters');
+
+  const inputParameter = findInputParameter(inputOutput, binding);
+
+  commandStack.execute('element.updateModdleProperties', {
+    element,
+    moddleElement: inputOutput,
+    properties: { inputParameters: without(inputParameters, inputParameter) }
+  });
+}

--- a/src/provider/element-templates/properties/InputProperties.js
+++ b/src/provider/element-templates/properties/InputProperties.js
@@ -54,7 +54,7 @@ export function InputProperties(props) {
     });
 
     // (1) remove name entry
-    entries.shift();
+    entries = removeEntry(entries, '-name');
   }
 
   // (2) add local variable assignment entry
@@ -216,4 +216,10 @@ function removeInputParameter(element, binding, commandStack) {
     moddleElement: inputOutput,
     properties: { inputParameters: without(inputParameters, inputParameter) }
   });
+}
+
+function removeEntry(entries, suffix) {
+  const entry = entries.find(({ id }) => id.endsWith(suffix));
+
+  return without(entries, entry);
 }

--- a/src/provider/element-templates/properties/OutputProperties.js
+++ b/src/provider/element-templates/properties/OutputProperties.js
@@ -1,0 +1,263 @@
+import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+
+import TextField from '@bpmn-io/properties-panel/lib/components/entries/TextField';
+import ToggleSwitch from '@bpmn-io/properties-panel/lib/components/entries/ToggleSwitch';
+
+import { containsSpace } from '../../bpmn/utils/ValidationUtil';
+
+import {
+  findExtension,
+  findOutputParameter
+} from '../Helper';
+
+import { useService } from '../../../hooks';
+
+import { without } from 'min-dash';
+
+import { createElement } from '../../../utils/ElementUtil';
+
+import { createOutputParameter } from '../CreateHelper';
+
+
+export function OutputProperties(props) {
+  const {
+    element,
+    index,
+    property
+  } = props;
+
+  const {
+    binding,
+    description,
+    label
+  } = property;
+
+  const businessObject = getBusinessObject(element),
+        inputOutput = findExtension(businessObject, 'camunda:InputOutput');
+
+  if (!inputOutput) {
+    return;
+  }
+
+  const outputParameter = findOutputParameter(inputOutput, binding);
+
+  const id = `${ element.id }-outputParameter-${ index }`;
+
+  let entries = [];
+
+  // (1) add description entry
+  if (description) {
+    entries.push({
+      id: `${ id }-description`,
+      component: <Description id={ `${ id }-description` } text={ description } />
+    });
+  }
+
+  // (2) add local variable assignment entry
+  entries.push({
+    id: `${ id }-local-variable-assignment`,
+    component: <ProcessVariableAssignment element={ element } id={ `${ id }-local-variable-assignment` } property={ property } />
+  });
+
+  if (outputParameter) {
+
+    // (3) add assign to process variable entry
+    entries.push({
+      id: `${ id }-assign-to-process-variable`,
+      component: <AssignToProcessVariable element={ element } id={ `${ id }-assign-to-process-variable` } property={ property } />
+    });
+  }
+
+  const item = {
+    id,
+    label,
+    entries
+  };
+
+  return item;
+}
+
+// TODO(philippfromme): add text entry to properties-panel
+function Description(props) {
+  const {
+    id,
+    text
+  } = props;
+
+  return <div class="bio-properties-panel-entry" data-entry-id={ id }>
+    <div class="bio-properties-panel-description">{ text }</div>
+  </div>;
+}
+
+function ProcessVariableAssignment(props) {
+  const {
+    element,
+    id,
+    property
+  } = props;
+
+  const { binding } = property;
+
+  const bpmnFactory = useService('bpmnFactory'),
+        commandStack = useService('commandStack'),
+        translate = useService('translate');
+
+  const businessObject = getBusinessObject(element),
+        inputOutput = findExtension(businessObject, 'camunda:InputOutput');
+
+  const outputParameter = findOutputParameter(inputOutput, binding);
+
+  const getValue = () => {
+    return findOutputParameter(inputOutput, binding);
+  };
+
+  const setValue = (value) => {
+    if (value) {
+      addOutputParameter(element, property, bpmnFactory, commandStack);
+    } else {
+      removeOutputParameter(element, binding, commandStack);
+    }
+  };
+
+  return ToggleSwitch({
+    id,
+    label: translate('Process variable assignment'),
+    switcherLabel: outputParameter ?
+      translate('On') :
+      translate('Off'),
+    description: outputParameter ?
+      '' :
+      translate('Parameter won\'t be available in process scope.'),
+    getValue,
+    setValue
+  });
+}
+
+function AssignToProcessVariable(props) {
+  const {
+    element,
+    id,
+    property
+  } = props;
+
+  const { binding } = property;
+
+  const inputOutput = findExtension(element, 'camunda:InputOutput'),
+        outputParameter = findOutputParameter(inputOutput, binding);
+
+  const commandStack = useService('commandStack'),
+        debounce = useService('debounceInput'),
+        translate = useService('translate');
+
+  const setValue = (value) => {
+    commandStack.execute('element.updateModdleProperties', {
+      element,
+      moddleElement: outputParameter,
+      properties: { name: value }
+    });
+  };
+
+  const getValue = () => {
+    return outputParameter.get('camunda:name');
+  };
+
+  const validate = (value) => {
+    if (!value) {
+      return translate('Process variable name must not be empty.');
+    } else if (containsSpace(value)) {
+      return translate('Process variable name must not contain spaces.');
+    }
+  };
+
+  return TextField({
+    debounce,
+    element: outputParameter,
+    id,
+    label: translate('Assign to process variable'),
+    getValue,
+    setValue,
+    validate
+  });
+}
+
+function addOutputParameter(element, property, bpmnFactory, commandStack) {
+  const {
+    binding,
+    value
+  } = property;
+
+  const commands = [];
+
+  const businessObject = getBusinessObject(element);
+
+  let extensionElements = businessObject.get('extensionElements');
+
+  // (1) ensure bpmn:ExtensionElements
+  if (!extensionElements) {
+    extensionElements = createElement(
+      'bpmn:ExtensionElements',
+      { values: [] },
+      businessObject,
+      bpmnFactory
+    );
+
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: businessObject,
+        properties: { extensionElements }
+      }
+    });
+  }
+
+  // (2) ensure camunda:InputOutput
+  let inputOutput = findExtension(businessObject, 'camunda:InputOutput');
+
+  if (!inputOutput) {
+    inputOutput = createElement('camunda:InputOutput', {
+      inputParameters: [],
+      outputParameters: []
+    }, extensionElements, bpmnFactory);
+
+    commands.push({
+      cmd: 'element.updateModdleProperties',
+      context: {
+        element,
+        moddleElement: extensionElements,
+        properties: { values: [ ...extensionElements.get('values'), inputOutput ] }
+      }
+    });
+  }
+
+  // (3) add camunda:InputParameter
+  const outputParamter = createOutputParameter(binding, value, bpmnFactory);
+
+  outputParamter.$parent = inputOutput;
+
+  commands.push({
+    cmd: 'element.updateModdleProperties',
+    context: {
+      element,
+      moddleElement: inputOutput,
+      properties: { outputParameters: [ ...inputOutput.get('camunda:outputParameters'), outputParamter ] }
+    }
+  });
+
+  commandStack.execute('properties-panel.multi-command-executor', commands);
+}
+
+function removeOutputParameter(element, binding, commandStack) {
+  const businessObject = getBusinessObject(element);
+
+  const inputOutput = findExtension(businessObject, 'camunda:InputOutput'),
+        outputParameters = inputOutput.get('camunda:outputParameters');
+
+  const outputParameter = findOutputParameter(inputOutput, binding);
+
+  commandStack.execute('element.updateModdleProperties', {
+    element,
+    moddleElement: inputOutput,
+    properties: { outputParameters: without(outputParameters, outputParameter) }
+  });
+}

--- a/src/provider/element-templates/properties/index.js
+++ b/src/provider/element-templates/properties/index.js
@@ -1,3 +1,4 @@
 export { CustomProperties } from './CustomProperties';
+export { ErrorProperties } from './ErrorProperties';
 export { InputProperties } from './InputProperties';
 export { OutputProperties } from './OutputProperties';

--- a/src/provider/element-templates/properties/index.js
+++ b/src/provider/element-templates/properties/index.js
@@ -1,2 +1,3 @@
 export { CustomProperties } from './CustomProperties';
 export { InputProperties } from './InputProperties';
+export { OutputProperties } from './OutputProperties';

--- a/src/provider/element-templates/properties/index.js
+++ b/src/provider/element-templates/properties/index.js
@@ -1,1 +1,2 @@
 export { CustomProperties } from './CustomProperties';
+export { InputProperties } from './InputProperties';

--- a/test/spec/provider/element-templates/properties/ErrorProperties.bpmn
+++ b/test/spec/provider/element-templates/properties/ErrorProperties.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1jhfqto" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
+  <bpmn:process id="Process_0jg7qce" isExecutable="true">
+    <bpmn:serviceTask id="ServiceTask_1" camunda:modelerTemplate="com.example.ExternalTaskWorker" camunda:type="external">
+      <bpmn:extensionElements>
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1x790hf" errorRef="Error_error-1_19uan50" expression="${error.expression1}" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_1mfya2c" errorRef="Error_error-2_160l0k8" expression="${error.expression2}" />
+        <camunda:errorEventDefinition id="ErrorEventDefinition_0wrs1j5" errorRef="Error_error-3_05nhsr3" expression="${error.expression3}" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ServiceTask_empty" camunda:modelerTemplate="com.example.EmptyTemplate" />
+  </bpmn:process>
+  <bpmn:error id="Error_error-1_19uan50" name="error-name-1" errorCode="error-code-1" camunda:errorMessage="error-message-1" />
+  <bpmn:error id="Error_error-2_160l0k8" name="error-name-2" errorCode="error-code-2" camunda:errorMessage="error-message-2" />
+  <bpmn:error id="Error_error-3_05nhsr3" name="error-name-3" errorCode="error-code-3" camunda:errorMessage="error-message-3" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jg7qce">
+      <bpmndi:BPMNShape id="Activity_07xpg3x_di" bpmnElement="ServiceTask_1">
+        <dc:Bounds x="200" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qhu82r_di" bpmnElement="ServiceTask_empty">
+        <dc:Bounds x="200" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/element-templates/properties/ErrorProperties.json
+++ b/test/spec/provider/element-templates/properties/ErrorProperties.json
@@ -1,0 +1,152 @@
+[
+  {
+    "name": "External Task Worker",
+    "id": "com.example.ExternalTaskWorker",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": [
+      {
+        "type": "Hidden",
+        "value": "external",
+        "binding": {
+          "type": "property",
+          "name": "camunda:type"
+        }
+      },
+      {
+        "label": "error-name-1",
+        "value": "${error.expression1}",
+        "binding": {
+          "type": "camunda:errorEventDefinition",
+          "errorRef": "error-1"
+        }
+      },
+      {
+        "label": "error-name-2",
+        "value": "${error.expression2}",
+        "binding": {
+          "type": "camunda:errorEventDefinition",
+          "errorRef": "error-2"
+        }
+      },
+      {
+        "label": "error-name-3",
+        "value": "${error.expression3}",
+        "binding": {
+          "type": "camunda:errorEventDefinition",
+          "errorRef": "error-3"
+        }
+      }
+    ],
+    "scopes": [
+      {
+        "type": "bpmn:Error",
+        "id": "error-1",
+        "properties": [
+          {
+            "label": "Error Code",
+            "type": "Hidden",
+            "value": "error-code-1",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "label": "Error Message",
+            "type": "Hidden",
+            "value": "error-message-1",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "label": "Error Name",
+            "type": "Hidden",
+            "value": "error-name-1",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      },
+      {
+        "type": "bpmn:Error",
+        "id": "error-2",
+        "properties": [
+          {
+            "label": "Error Code",
+            "type": "Hidden",
+            "value": "error-code-2",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "label": "Error Message",
+            "type": "Hidden",
+            "value": "error-message-2",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "label": "Error Name",
+            "type": "Hidden",
+            "value": "error-name-2",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      },
+      {
+        "type": "bpmn:Error",
+        "id": "error-3",
+        "properties": [
+          {
+            "label": "Error Code",
+            "type": "Hidden",
+            "value": "error-code-3",
+            "binding": {
+              "type": "property",
+              "name": "errorCode"
+            }
+          },
+          {
+            "label": "Error Message",
+            "type": "Hidden",
+            "value": "error-message-3",
+            "binding": {
+              "type": "property",
+              "name": "camunda:errorMessage"
+            }
+          },
+          {
+            "label": "Error Name",
+            "type": "Hidden",
+            "value": "error-name-3",
+            "binding": {
+              "type": "property",
+              "name": "name"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Empty Template",
+    "id": "com.example.EmptyTemplate",
+    "appliesTo": [
+      "bpmn:ServiceTask"
+    ],
+    "properties": []
+  }
+]

--- a/test/spec/provider/element-templates/properties/ErrorProperties.spec.js
+++ b/test/spec/provider/element-templates/properties/ErrorProperties.spec.js
@@ -1,0 +1,151 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  bootstrapPropertiesPanel,
+  getBpmnJS
+} from 'test/TestHelper';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import { query as domQuery } from 'min-dom';
+
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import camundaModdlePackage from 'camunda-bpmn-moddle/resources/camunda';
+
+import BpmnPropertiesPanel from 'src/render';
+import elementTemplatesModule from 'src/provider/element-templates';
+
+import diagramXML from './ErrorProperties.bpmn';
+import elementTemplates from './ErrorProperties.json';
+
+
+describe('provider/element-templates - ErrorProperties', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    container,
+    debounceInput: false,
+    elementTemplates,
+    moddleExtensions: {
+      camunda: camundaModdlePackage
+    },
+    modules: [
+      BpmnPropertiesPanel,
+      coreModule,
+      elementTemplatesModule,
+      modelingModule
+    ]
+  }));
+
+
+  it('should not display add button', async function() {
+
+    // when
+    await expectSelected('ServiceTask_1');
+
+    // then
+    const group = domQuery('[data-group-id=\'group-CamundaPlatform__Errors\']', container),
+          button = domQuery('.bio-properties-panel-add-entry', group);
+
+    expect(button).not.to.exist;
+  });
+
+
+  it('should not display remove button', async function() {
+
+    // when
+    await expectSelected('ServiceTask_1');
+
+    // then
+    const group = domQuery('[data-group-id=\'group-CamundaPlatform__Errors\']', container),
+          button = domQuery('.bio-properties-panel-remove-entry', group);
+
+    expect(button).not.to.exist;
+  });
+
+
+  describe('global error referenced entry', function() {
+
+    it('should not display global error referenced entry', async function() {
+
+      // when
+      await expectSelected('ServiceTask_1');
+
+      // then
+      const entry = findEntry('ServiceTask_1-errorEventDefinition-0-errorRef', container);
+
+      expect(entry).not.to.exist;
+    });
+
+  });
+
+
+  describe('throw expression entry', function() {
+
+    it('should display disabled throw expression', async function() {
+
+      // when
+      await expectSelected('ServiceTask_1');
+
+      // then
+      const entry = findEntry('ServiceTask_1-errorEventDefinition-0-expression', container),
+            input = findInput('text', entry);
+
+      expect(input).to.exist;
+      expect(input.disabled).to.be.true;
+    });
+
+  });
+
+
+  describe('entries', function() {
+
+    it('should display other entries', async function() {
+
+      // when
+      await expectSelected('ServiceTask_1');
+
+      // then
+      const errorNameEntry = findEntry('ServiceTask_1-errorEventDefinition-0-errorName', container),
+            errorCodeEntry = findEntry('ServiceTask_1-errorEventDefinition-0-errorCode', container),
+            errorMessageEntry = findEntry('ServiceTask_1-errorEventDefinition-0-errorMessage', container);
+
+      expect(errorNameEntry).to.exist;
+      expect(errorCodeEntry).to.exist;
+      expect(errorMessageEntry).to.exist;
+    });
+
+  });
+
+});
+
+
+// helpers //////////
+
+function expectSelected(id) {
+  return getBpmnJS().invoke(async function(elementRegistry, selection) {
+    const element = elementRegistry.get(id);
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    return element;
+  });
+}
+
+function findEntry(id, container) {
+  return domQuery(`[data-entry-id='${ id }']`, container);
+}
+
+function findInput(type, container) {
+  return domQuery(`input[type='${ type }']`, container);
+}

--- a/test/spec/provider/element-templates/properties/InputProperties.bpmn
+++ b/test/spec/provider/element-templates/properties/InputProperties.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.4.0-dev">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="SimpleTask" name="Simple Task" camunda:modelerTemplate="my.domain.SimpleWorkerTask">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="recipient">recipient</camunda:inputParameter>
+          <camunda:inputParameter name="noLabel" />
+          <camunda:inputParameter name="withDescription" />
+          <camunda:inputParameter name="template"><camunda:script scriptFormat="freemaker" /></camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+    </bpmn:task>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_0zadlfo_di" bpmnElement="SimpleTask">
+        <dc:Bounds x="79" y="53" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/element-templates/properties/InputProperties.json
+++ b/test/spec/provider/element-templates/properties/InputProperties.json
@@ -1,0 +1,47 @@
+[
+  {
+    "name": "SimpleWorkerTask",
+    "id": "my.domain.SimpleWorkerTask",
+    "appliesTo": ["bpmn:Task"],
+    "properties": [
+      {
+        "label": "recipient",
+        "value": "recipient",
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "recipient"
+        }
+      },
+      {
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "noLabel"
+        }
+      },
+      {
+        "label": "withDescription",
+        "description": "foo bar",
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "withDescription"
+        }
+      },
+      {
+        "label": "template",
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "template",
+          "scriptFormat": "freemarker"
+        }
+      },
+      {
+        "label": "notCreated",
+        "value": "${foo}",
+        "binding": {
+          "type": "camunda:inputParameter",
+          "name": "notCreated"
+        }
+      }
+    ]
+  }
+]

--- a/test/spec/provider/element-templates/properties/InputProperties.spec.js
+++ b/test/spec/provider/element-templates/properties/InputProperties.spec.js
@@ -1,0 +1,368 @@
+import TestContainer from 'mocha-test-container-support';
+
+import {
+  bootstrapPropertiesPanel,
+  getBpmnJS,
+  inject
+} from 'test/TestHelper';
+
+import {
+  act
+} from '@testing-library/preact';
+
+import { query as domQuery } from 'min-dom';
+
+import {
+  findExtension,
+  findInputParameter
+} from '../../../../../src/provider/element-templates/Helper';
+
+import coreModule from 'bpmn-js/lib/core';
+import modelingModule from 'bpmn-js/lib/features/modeling';
+import camundaModdlePackage from 'camunda-bpmn-moddle/resources/camunda';
+
+import BpmnPropertiesPanel from 'src/render';
+import elementTemplatesModule from 'src/provider/element-templates';
+
+import diagramXML from './InputProperties.bpmn';
+import elementTemplates from './InputProperties.json';
+
+
+describe('provider/element-templates - InputProperties', function() {
+
+  let container;
+
+  beforeEach(function() {
+    container = TestContainer.get(this);
+  });
+
+  beforeEach(bootstrapPropertiesPanel(diagramXML, {
+    container,
+    debounceInput: false,
+    elementTemplates,
+    moddleExtensions: {
+      camunda: camundaModdlePackage
+    },
+    modules: [
+      BpmnPropertiesPanel,
+      coreModule,
+      elementTemplatesModule,
+      modelingModule
+    ]
+  }));
+
+
+  it('should not display add button', async function() {
+
+    // when
+    await expectSelected('SimpleTask');
+
+    // then
+    const group = domQuery('[data-group-id=\'group-CamundaPlatform__Input\']', container),
+          button = domQuery('.bio-properties-panel-add-entry', group);
+
+    expect(button).not.to.exist;
+  });
+
+
+  it('should not display remove button', async function() {
+
+    // when
+    await expectSelected('SimpleTask');
+
+    // then
+    const group = domQuery('[data-group-id=\'group-CamundaPlatform__Input\']', container),
+          button = domQuery('.bio-properties-panel-remove-entry', group);
+
+    expect(button).not.to.exist;
+  });
+
+
+  describe('label', function() {
+
+    it('should display label as label', async function() {
+
+      // when
+      await expectSelected('SimpleTask');
+
+      // then
+      const entry = findEntry('SimpleTask-inputParameter-0', container);
+
+      expect(entry).to.exist;
+
+      const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', entry);
+
+      expect(label).to.exist;
+      expect(label.innerText).to.equal('recipient');
+    });
+
+
+    it('should display binding name as label', async function() {
+
+      // when
+      await expectSelected('SimpleTask');
+
+      // then
+      const entry = findEntry('SimpleTask-inputParameter-1', container);
+
+      expect(entry).to.exist;
+
+      const label = domQuery('.bio-properties-panel-collapsible-entry-header-title', entry);
+
+      expect(label).to.exist;
+      expect(label.innerText).to.equal('noLabel');
+    });
+
+  });
+
+
+  describe('name entry', function() {
+
+    it('should not display name entry', async function() {
+
+      // when
+      await expectSelected('SimpleTask');
+
+      // then
+      const entry = findEntry('SimpleTask-inputParameter-1-name', container);
+
+      expect(entry).not.to.exist;
+    });
+
+  });
+
+
+  describe('description entry', function() {
+
+    it('should display description entry', async function() {
+
+      // when
+      await expectSelected('SimpleTask');
+
+      // then
+      const entry = findEntry('SimpleTask-inputParameter-2', container);
+
+      expect(entry).to.exist;
+
+      const description = findEntry('SimpleTask-inputParameter-2-description', entry);
+
+      expect(description).to.exist;
+      expect(description.innerText).to.equal('foo bar');
+    });
+
+  });
+
+
+  describe('local variable assignment entry', function() {
+
+    describe('toggle on', function() {
+
+      let input;
+
+      beforeEach(async function() {
+        await expectSelected('SimpleTask');
+
+        expandGroup('group-CamundaPlatform__Input', container);
+
+        expandCollapsibleEntry('SimpleTask-inputParameter-4', container);
+
+        const entry = findEntry('SimpleTask-inputParameter-4-local-variable-assignment', container);
+
+        input = findInput('checkbox', entry);
+
+        // assume
+        expect(input.checked).to.be.false;
+      });
+
+
+      it('should <do>', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('SimpleTask');
+
+        // when
+        input.click();
+
+        // then
+        const inputOutput = findExtension(task, 'camunda:InputOutput'),
+              inputParameter = findInputParameter(inputOutput, { name: 'notCreated' });
+
+        expect(inputParameter).to.exist;
+        expect(inputParameter.get('camunda:name')).to.equal('notCreated');
+        expect(inputParameter.get('camunda:value')).to.equal('${foo}');
+      }));
+
+
+      it('should <undo>', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('SimpleTask');
+
+        input.click();
+
+        // when
+        commandStack.undo();
+
+        // then
+        const inputOutput = findExtension(task, 'camunda:InputOutput'),
+              inputParameter = findInputParameter(inputOutput, { name: 'notCreated' });
+
+        expect(inputParameter).not.to.exist;
+      }));
+
+
+      it('should <redo>', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('SimpleTask');
+
+        input.click();
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const inputOutput = findExtension(task, 'camunda:InputOutput'),
+              inputParameter = findInputParameter(inputOutput, { name: 'notCreated' });
+
+        expect(inputParameter).to.exist;
+        expect(inputParameter.get('camunda:name')).to.equal('notCreated');
+        expect(inputParameter.get('camunda:value')).to.equal('${foo}');
+      }));
+
+    });
+
+
+    describe('toggle off', function() {
+
+      let input;
+
+      beforeEach(async function() {
+        await expectSelected('SimpleTask');
+
+        expandGroup('group-CamundaPlatform__Input', container);
+
+        expandCollapsibleEntry('SimpleTask-inputParameter-0', container);
+
+        const entry = findEntry('SimpleTask-inputParameter-0-local-variable-assignment', container);
+
+        input = findInput('checkbox', entry);
+
+        // assume
+        expect(input.checked).to.be.true;
+      });
+
+
+      it('should <do>', inject(function(elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('SimpleTask');
+
+        // when
+        input.click();
+
+        // then
+        const inputOutput = findExtension(task, 'camunda:InputOutput'),
+              inputParameter = findInputParameter(inputOutput, { name: 'recipient' });
+
+        expect(inputParameter).not.to.exist;
+      }));
+
+
+      it('should <undo>', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('SimpleTask');
+
+        input.click();
+
+        // when
+        commandStack.undo();
+
+        // then
+        const inputOutput = findExtension(task, 'camunda:InputOutput'),
+              inputParameter = findInputParameter(inputOutput, { name: 'recipient' });
+
+        expect(inputParameter).to.exist;
+        expect(inputParameter.get('camunda:name')).to.equal('recipient');
+        expect(inputParameter.get('camunda:value')).to.equal('recipient');
+      }));
+
+
+      it('should <redo>', inject(function(commandStack, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('SimpleTask');
+
+        input.click();
+
+        // when
+        commandStack.undo();
+        commandStack.redo();
+
+        // then
+        const inputOutput = findExtension(task, 'camunda:InputOutput'),
+              inputParameter = findInputParameter(inputOutput, { name: 'recipient' });
+
+        expect(inputParameter).not.to.exist;
+      }));
+
+    });
+
+  });
+
+
+  describe('entries', function() {
+
+    it('should display other entries', async function() {
+
+      // when
+      await expectSelected('SimpleTask');
+
+      // then
+      const typeEntry = findEntry('SimpleTask-inputParameter-0-type', container),
+            stringOrExpressionEntry = findEntry('SimpleTask-inputParameter-0-stringOrExpression', container);
+
+      expect(typeEntry).to.exist;
+      expect(stringOrExpressionEntry).to.exist;
+    });
+
+  });
+
+});
+
+
+// helpers //////////
+
+function expectSelected(id) {
+  return getBpmnJS().invoke(async function(elementRegistry, selection) {
+    const element = elementRegistry.get(id);
+
+    await act(() => {
+      selection.select(element);
+    });
+
+    return element;
+  });
+}
+
+function expandGroup(id, container) {
+  const header = domQuery(`[data-group-id='${ id }'] .bio-properties-panel-group-header`, container);
+
+  header.click();
+}
+
+function expandCollapsibleEntry(id, container) {
+  const header = domQuery(`[data-entry-id='${ id }'] .bio-properties-panel-collapsible-entry-header`, container);
+
+  header.click();
+}
+
+function findEntry(id, container) {
+  return domQuery(`[data-entry-id='${ id }']`, container);
+}
+
+function findInput(type, container) {
+  return domQuery(`input[type='${ type }']`, container);
+}

--- a/test/spec/provider/element-templates/properties/OutputProperties.bpmn
+++ b/test/spec/provider/element-templates/properties/OutputProperties.bpmn
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.4.0-dev">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:task id="SimpleTask" name="Simple Task" camunda:modelerTemplate="my.domain.SimpleWorkerTask">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:outputParameter name="resultStatus">${resultStatus}</camunda:outputParameter>
+          <camunda:outputParameter name="foo">foo</camunda:outputParameter>
+          <camunda:outputParameter name="">emptyName</camunda:outputParameter>
+          <camunda:outputParameter name="foo bar">spaces</camunda:outputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+    </bpmn:task>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_0zadlfo_di" bpmnElement="SimpleTask">
+        <dc:Bounds x="79" y="53" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/test/spec/provider/element-templates/properties/OutputProperties.json
+++ b/test/spec/provider/element-templates/properties/OutputProperties.json
@@ -1,0 +1,49 @@
+[
+  {
+    "name": "SimpleWorkerTask",
+    "id": "my.domain.SimpleWorkerTask",
+    "appliesTo": ["bpmn:Task"],
+    "properties": [
+      {
+        "label": "resultStatus",
+        "value": "resultStatus",
+        "binding": {
+          "type": "camunda:outputParameter",
+          "source": "${resultStatus}"
+        }
+      },
+      {
+        "label": "withDescription",
+        "description": "foo bar",
+        "value": "foo",
+        "binding": {
+          "type": "camunda:outputParameter",
+          "source": "foo"
+        }
+      },
+      {
+        "label": "emptyName",
+        "binding": {
+          "type": "camunda:outputParameter",
+          "source": "emptyName"
+        }
+      },
+      {
+        "label": "spaces",
+        "value": "foo bar",
+        "binding": {
+          "type": "camunda:outputParameter",
+          "source": "spaces"
+        }
+      },
+      {
+        "label": "notCreated",
+        "value": "foo",
+        "binding": {
+          "type": "camunda:outputParameter",
+          "source": "notCreated"
+        }
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Add element template properties for inputs, outputs and errors reusing existing implementations.

# Input Parameters

* reuse existing group and entry
* display template label or binding name as title
* do not display name entry
* display description
* display _Local Variable Assignment_ toggle

![image](https://user-images.githubusercontent.com/7633572/140078238-0eebcee4-ec1a-45b2-bd78-831a24cecb5e.png)

# Output Parameters

* reuse existing group
* display description
* display _Process Variable Assignment_ toggle
* display _Assign to process variable_

![image](https://user-images.githubusercontent.com/7633572/140280881-bd5e1d05-8c2e-40df-8f05-076cb3b2c972.png)

# Errors

* reuse existing group and entry
* disable _Throw expression_ entry
* do not display _Global error referenced_ entry

![image](https://user-images.githubusercontent.com/7633572/140078616-fe794e67-a0be-4c60-ba8c-5d7b3a4f7a04.png)

---

Depends on https://github.com/bpmn-io/properties-panel/pull/115

Closes https://github.com/bpmn-io/bpmn-properties-panel/issues/147