### PR TITLE
style(element-templates): adjust select hover color

### DIFF
--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -1,8 +1,8 @@
 .bio-properties-panel {
-  --select-template-background-color: var(--add-entry-hover-background-color);
+  --select-template-background-color: var(--color-blue-205-100-50);
   --select-template-hover-background-color: var(--color-blue-205-100-45);
-  --select-template-fill-color: var(--add-entry-hover-fill-color);
-  --select-template-label-color: var(--add-entry-label-color);
+  --select-template-fill-color: var(--color-white);
+  --select-template-label-color: var(--color-white);
 }
 
 .bio-properties-panel-group-header-button.bio-properties-panel-select-template-button {

--- a/assets/element-templates.css
+++ b/assets/element-templates.css
@@ -1,14 +1,24 @@
+.bio-properties-panel {
+  --select-template-background-color: var(--add-entry-hover-background-color);
+  --select-template-hover-background-color: var(--color-blue-205-100-45);
+  --select-template-fill-color: var(--add-entry-hover-fill-color);
+  --select-template-label-color: var(--add-entry-label-color);
+}
+
 .bio-properties-panel-group-header-button.bio-properties-panel-select-template-button {
   padding-left: 6px;
   margin-right: 19px;
 
-  background-color: var(--add-entry-hover-background-color);
-  fill: var(--add-entry-hover-fill-color);
+  background-color: var(--select-template-background-color);
+  fill: var(--select-template-fill-color);
   border-radius: 11px;
+}
+
+.bio-properties-panel-group-header-button.bio-properties-panel-select-template-button:hover {
+  background-color: var(--select-template-hover-background-color);
 }
 
 .bio-properties-panel-select-template-button .bio-properties-panel-select-template-button-label {
   padding: 4px 6px 3px 2px;
-
-  color: var(--add-entry-label-color);
+  color: var(--select-template-label-color);
 }


### PR DESCRIPTION
Added the hover background color for the select button. I encountered this during quick testing. 

This ensures we are in line with the [design prototype](https://fluffy-fiesta-212e1c7c.pages.github.io/prototypes/visual-ide/v15/).

![Kapture 2021-11-04 at 16 12 35](https://user-images.githubusercontent.com/9433996/140343273-6c373a19-a2cb-4879-9f94-d10fd1c09d56.gif)

