### PR TITLE
Show template group only if template can be applied

### DIFF
--- a/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
+++ b/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
@@ -1,3 +1,5 @@
+import { isAny } from 'bpmn-js/lib/features/modeling/util/ModelingUtil';
+
 import {
   ElementTemplatesGroup,
   TemplateProps
@@ -9,6 +11,8 @@ import {
   InputProperties,
   OutputProperties
 } from './properties';
+
+import { getTemplateId } from './Helper';
 
 const CAMUNDA_ERROR_EVENT_DEFINITION_TYPE = 'camunda:errorEventDefinition',
       CAMUNDA_INPUT_PARAMETER_TYPE = 'camunda:inputParameter',
@@ -27,6 +31,10 @@ export default class ElementTemplatesPropertiesProvider {
 
   getGroups(element) {
     return (groups) => {
+
+      if (!this._shouldShowTemplateProperties(element)) {
+        return groups;
+      }
 
       // (0) Copy provided groups
       groups = groups.slice();
@@ -62,6 +70,11 @@ export default class ElementTemplatesPropertiesProvider {
     };
   }
 
+  _shouldShowTemplateProperties(element) {
+    return getTemplateId(element) || this._elementTemplates.getAll().some(template => {
+      return isAny(element, template.appliesTo);
+    });
+  }
 }
 
 ElementTemplatesPropertiesProvider.$inject = [ 'elementTemplates', 'propertiesPanel' ];

--- a/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
+++ b/src/provider/element-templates/ElementTemplatesPropertiesProvider.js
@@ -69,24 +69,6 @@ ElementTemplatesPropertiesProvider.$inject = [ 'elementTemplates', 'propertiesPa
 
 // helper /////////////////////
 
-/**
- *
- * @param {string} id
- * @param {Array<{ id: string }} groups
- * @param {Array<{ id: string }>} groupsToAdd
- */
-function addGroupsAfter(id, groups, groupsToAdd) {
-  const index = groups.findIndex(group => group.id === id);
-
-  if (index !== -1) {
-    groups.splice(index, 0, ...groupsToAdd);
-  } else {
-
-    // add in the beginning if group with provided id is missing
-    groups.unshift(...groupsToAdd);
-  }
-}
-
 function updateInputGroup(groups, element, elementTemplate) {
   const inputGroup = findGroup(groups, 'CamundaPlatform__Input');
 
@@ -159,7 +141,23 @@ function updateErrorsGroup(groups, element, elementTemplate) {
   });
 }
 
-// helpers //////////
+/**
+ *
+ * @param {string} id
+ * @param {Array<{ id: string }} groups
+ * @param {Array<{ id: string }>} groupsToAdd
+ */
+function addGroupsAfter(id, groups, groupsToAdd) {
+  const index = groups.findIndex(group => group.id === id);
+
+  if (index !== -1) {
+    groups.splice(index, 0, ...groupsToAdd);
+  } else {
+
+    // add in the beginning if group with provided id is missing
+    groups.unshift(...groupsToAdd);
+  }
+}
 
 function findGroup(groups, id) {
   return groups.find((group) => group.id === id);

--- a/test/spec/provider/element-templates/ElementTemplatesPropertiesProvider.spec.js
+++ b/test/spec/provider/element-templates/ElementTemplatesPropertiesProvider.spec.js
@@ -69,6 +69,25 @@ describe('provider/element-templates - ElementTemplates', function() {
         expect(group).to.exist;
       })
     );
+
+
+    it('should NOT display template group if no templates are available for element', inject(
+      async function(elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Process_1');
+
+        // when
+        await act(() => {
+          selection.select(element);
+        });
+
+        // then
+        const group = domQuery('[data-group-id="group-template"]', container);
+
+        expect(group).not.to.exist;
+      })
+    );
   });
 
 


### PR DESCRIPTION
Notice that the group will also be displayed if the template is unknown so that you can remove/unlink it.

Closes #158

Built on top of https://github.com/bpmn-io/bpmn-properties-panel/pull/155