### PR TITLE
fix(element-templates): set property to empty string when erased

### DIFF
--- a/src/provider/element-templates/properties/CustomProperties.js
+++ b/src/provider/element-templates/properties/CustomProperties.js
@@ -578,7 +578,9 @@ function propertySetter(bpmnFactory, commandStack, element, property, scope) {
             propertyValue = undefined;
           }
         } else {
-          propertyValue = value;
+
+          // make sure we don't remove the property
+          propertyValue = value || '';
         }
       }
 

--- a/test/spec/provider/element-templates/properties/CustomProperties.bpmn
+++ b/test/spec/provider/element-templates/properties/CustomProperties.bpmn
@@ -31,6 +31,7 @@
       </bpmn:extensionElements>
     </bpmn:task>
     <bpmn:task id="AsyncTask" name="AsyncTask" camunda:modelerTemplate="my.awesome.Task" camunda:asyncBefore="true" />
+    <bpmn:task id="AsyncTask_2" name="AsyncTask_2" camunda:modelerTemplate="my.awesome.Task_2" camunda:asyncBefore="true" camunda:jobPriority="1200" />
     <bpmn:task id="WebserviceTask" name="Webservice Task" camunda:modelerTemplate="com.mycompany.WsCaller">
       <bpmn:extensionElements>
         <camunda:properties>
@@ -131,6 +132,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_1nlqdin_di" bpmnElement="AsyncTask">
         <dc:Bounds x="291" y="53" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="AsyncTask_2_di" bpmnElement="AsyncTask_2">
+        <dc:Bounds x="291" y="143" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_1vmddbe_di" bpmnElement="WebserviceTask">
         <dc:Bounds x="424" y="53" width="100" height="80" />

--- a/test/spec/provider/element-templates/properties/CustomProperties.json
+++ b/test/spec/provider/element-templates/properties/CustomProperties.json
@@ -184,6 +184,33 @@
     "entriesVisible": true
   },
   {
+    "name": "AsyncAwesomeTask",
+    "id": "my.awesome.Task_2",
+    "appliesTo": [
+      "bpmn:Task"
+    ],
+    "properties": [
+      {
+        "label": "Are you awesome?",
+        "type": "Boolean",
+        "value": true,
+        "binding": {
+          "type": "property",
+          "name": "camunda:asyncBefore"
+        }
+      },
+      {
+        "label": "Priority",
+        "type": "String",
+        "binding": {
+          "type": "property",
+          "name": "camunda:jobPriority"
+        }
+      }
+    ],
+    "entriesVisible": true
+  },
+  {
     "name": "Custom ServiceTask",
     "id": "my.custom.ServiceTask",
     "appliesTo": [

--- a/test/spec/provider/element-templates/properties/CustomProperties.spec.js
+++ b/test/spec/provider/element-templates/properties/CustomProperties.spec.js
@@ -140,6 +140,25 @@ describe('provider/element-templates - CustomProperties', function() {
       expect(businessObject.get('camunda:asyncBefore')).to.be.false;
     });
 
+
+    it('should change String property to empty string when erased', async function() {
+
+      // given
+      const task = await expectSelected('AsyncTask_2'),
+            businessObject = getBusinessObject(task);
+
+      // when
+      const entry = findEntry('custom-entry-my.awesome.Task_2-1', container),
+            input = findInput('text', entry);
+
+      changeInput(input, '');
+
+      // then
+      expect(input.value).to.eql('');
+
+      expect(businessObject.get('camunda:jobPriority')).to.be.eql('');
+    });
+
   });
 
 


### PR DESCRIPTION
When I erase a String property, it should be set to an empty string in the XML.

Closes #168
