### PR TITLE
feat(render): update on element template changes

### DIFF
--- a/src/render/BpmnPropertiesPanel.js
+++ b/src/render/BpmnPropertiesPanel.js
@@ -120,6 +120,19 @@ export default function BpmnPropertiesPanel(props) {
     };
   }, [ selectedElement ]);
 
+  // (2d) element templates changed
+  useEffect(() => {
+    const onTemplatesChanged = () => {
+      _update(selectedElement);
+    };
+
+    eventBus.on('elementTemplates.changed', onTemplatesChanged);
+
+    return () => {
+      eventBus.off('elementTemplates.changed', onTemplatesChanged);
+    };
+  }, [ selectedElement ]);
+
   // (3) create properties panel context
   const bpmnPropertiesPanelContext = {
     selectedElement,

--- a/test/spec/BpmnPropertiesPanel.spec.js
+++ b/test/spec/BpmnPropertiesPanel.spec.js
@@ -175,6 +175,25 @@ describe('<BpmnPropertiesPanel>', function() {
     });
 
 
+    it('should update on element templates changed', function() {
+
+      // given
+      const updateSpy = sinon.spy();
+
+      const eventBus = new eventBusMock();
+
+      eventBus.on('propertiesPanel.updated', updateSpy);
+
+      createBpmnPropertiesPanel({ container, eventBus });
+
+      // when
+      eventBus.fire('elementTemplates.changed');
+
+      // then
+      expect(updateSpy).to.have.been.calledOnce;
+    });
+
+
     it('should notify on layout changed', function() {
 
       // given


### PR DESCRIPTION
Closes #171

![Kapture 2021-11-12 at 16 23 00](https://user-images.githubusercontent.com/9433996/141491228-21f084bd-231c-436c-95db-39b324bb1039.gif)

An alternative could be to keep this listener outside of the BpmnPropertiesPanel and add it to the element-templates module. But doing a rerender would be difficult this way.
