### PR TITLE
chore(CloudProvider): add documentation links for key inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [`@bpmn-io/bpmn-properties-panel`](https://github.com/bpm
 
 ___Note:__ Yet to be released changes appear here._
 
+* `CHORE`: add links to documentation for key fields of zeebe provider to better
+  guide the user
+
 ## 0.5.1
 
 * `CHORE`: replace textField with textArea for zeebe:userTaskForm input ([bfbe37d](https://github.com/bpmn-io/bpmn-properties-panel/commit/bfbe37d61095e235ce4a27d738cb638dcd69f991))

--- a/src/provider/zeebe/properties/ConditionProps.js
+++ b/src/provider/zeebe/properties/ConditionProps.js
@@ -106,7 +106,12 @@ function ConditionExpression(props) {
     label: translate('Condition expression'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    description:(
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/exclusive-gateways/exclusive-gateways#conditions" target="_blank" rel="noopener" title={ translate('Conditions documentation') }>
+        { translate('How to define conditions') }
+      </a>
+    )
   });
 }
 

--- a/src/provider/zeebe/properties/MessageProps.js
+++ b/src/provider/zeebe/properties/MessageProps.js
@@ -127,7 +127,8 @@ function SubscriptionCorrelationKey(props) {
     label: translate('Subscription correlation key'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    description: getCorrelationKeyDocumentation(element, translate)
   });
 }
 
@@ -170,4 +171,22 @@ function getSubscription(element) {
 function getSubscriptions(message) {
   const extensionElements = getExtensionElementsList(message, 'zeebe:Subscription');
   return extensionElements;
+}
+
+function getCorrelationKeyDocumentation(element, translate) {
+  if (is(element, 'bpmn:ReceiveTask')) {
+    return (
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/receive-tasks/receive-tasks/#messages" target="_blank" rel="noopener" title={ translate('Receive task documentation') }>
+        { translate('How to configure a receive task') }
+      </a>
+    );
+  }
+
+  if (is(element, 'bpmn:IntermediateCatchEvent') || is(element, 'bpmn:BoundaryEvent') || is(element, 'bpmn:StartEvent')) {
+    return (
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/message-events/message-events/#messages" target="_blank" rel="noopener" title={ translate('Message event documentation') }>
+        { translate('How to configure a message event') }
+      </a>
+    );
+  }
 }

--- a/src/provider/zeebe/properties/TargetProps.js
+++ b/src/provider/zeebe/properties/TargetProps.js
@@ -120,6 +120,11 @@ function TargetProcessId(props) {
     label: translate('Process ID'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    description: (
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/call-activities/call-activities" target="_blank" rel="noopener" title={ translate('Call activity documentation') }>
+        { translate('How to call another process') }
+      </a>
+    )
   });
 }

--- a/src/provider/zeebe/properties/TaskDefinitionProps.js
+++ b/src/provider/zeebe/properties/TaskDefinitionProps.js
@@ -1,4 +1,5 @@
 import {
+  is,
   getBusinessObject
 } from 'bpmn-js/lib/util/ModelUtil';
 
@@ -126,7 +127,8 @@ function TaskDefinitionType(props) {
     label: translate('Type'),
     getValue,
     setValue,
-    debounce
+    debounce,
+    description: getTypeDocumentation(element, translate)
   });
 }
 
@@ -222,4 +224,38 @@ function getTaskDefinition(element) {
   const businessObject = getBusinessObject(element);
 
   return getExtensionElementsList(businessObject, 'zeebe:TaskDefinition')[0];
+}
+
+function getTypeDocumentation(element, translate) {
+  if (is(element, 'bpmn:ServiceTask')) {
+    return (
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/service-tasks/service-tasks/#task-definition" target="_blank" rel="noopener" title={ translate('Service task documentation') }>
+        { translate('How to configure a service task') }
+      </a>
+    );
+  }
+
+  if (is(element, 'bpmn:BusinessRuleTask')) {
+    return (
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/business-rule-tasks/business-rule-tasks/#defining-a-task" target="_blank" rel="noopener" title={ translate('Business rule task documentation') }>
+        { translate('How to configure a business rule task') }
+      </a>
+    );
+  }
+
+  if (is(element, 'bpmn:ScriptTask')) {
+    return (
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/script-tasks/script-tasks/#defining-a-task" target="_blank" rel="noopener" title={ translate('Script task documentation') }>
+        { translate('How to configure a script task') }
+      </a>
+    );
+  }
+
+  if (is(element, 'bpmn:SendTask')) {
+    return (
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/send-tasks/send-tasks/#defining-a-task" target="_blank" rel="noopener" title={ translate('Send task documentation') }>
+        { translate('How to configure a send task') }
+      </a>
+    );
+  }
 }

--- a/src/provider/zeebe/properties/TimerProps.js
+++ b/src/provider/zeebe/properties/TimerProps.js
@@ -344,7 +344,7 @@ function getTimerEventDefinitionValueDescription(timerDefinitionType, translate)
         <li><code>2019-10-01T12:00:00Z</code> - { translate('UTC time') }</li>
         <li><code>2019-10-02T08:09:40+02:00</code> - { translate('UTC plus 2 hours zone offset') }</li>
       </ul>
-      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/timer-events/timer-events#time-date" target="_blank" rel="noopener">{ translate('Documentation: Timer events') }</a>
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/timer-events/timer-events#time-date" target="_blank" rel="noopener" title={ translate('Timer documentation') }>{ translate('How to configure a timer') }</a>
     </div>);
 
   case 'timeCycle':
@@ -354,7 +354,7 @@ function getTimerEventDefinitionValueDescription(timerDefinitionType, translate)
         <li><code>R5/PT10S</code> - { translate('every 10 seconds, up to 5 times') }</li>
         <li><code>R/P1D</code> - { translate('every day, infinitely') }</li>
       </ul>
-      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/timer-events/timer-events#time-cycle" target="_blank" rel="noopener">{ translate('Documentation: Timer events') }</a>
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/timer-events/timer-events#time-cycle" target="_blank" rel="noopener" title={ translate('Timer documentation') }>{ translate('How to configure a timer') }</a>
     </div>);
 
   case 'timeDuration':
@@ -365,7 +365,7 @@ function getTimerEventDefinitionValueDescription(timerDefinitionType, translate)
         <li><code>PT1H30M</code> - { translate('1 hour and 30 minutes') }</li>
         <li><code>P14D</code> - { translate('14 days') }</li>
       </ul>
-      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/timer-events/timer-events#time-duration" target="_blank" rel="noopener">{ translate('Documentation: Timer events') }</a>
+      <a href="https://docs.camunda.io/docs/reference/bpmn-processes/timer-events/timer-events#time-duration" target="_blank" rel="noopener" title={ translate('Timer documentation') }>{ translate('How to configure a timer') }</a>
     </div>);
   }
 }

--- a/test/spec/provider/zeebe/MessageProps.spec.js
+++ b/test/spec/provider/zeebe/MessageProps.spec.js
@@ -188,6 +188,42 @@ describe('provider/zeebe - MessageProps', function() {
       })
     );
 
+
+    it('should display correct documentation for events', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('StartEvent_1');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const documentationLink = domQuery('div[data-entry-id=messageSubscriptionCorrelationKey] a', container);
+
+      // then
+      expect(documentationLink).to.exist;
+      expect(documentationLink.title).to.equal('Message event documentation');
+    }));
+
+
+    it('should display correct documentation for receive tasks', inject(async function(elementRegistry, selection) {
+
+      // given
+      const startEvent = elementRegistry.get('ReceiveTask_empty');
+
+      await act(() => {
+        selection.select(startEvent);
+      });
+
+      // when
+      const documentationLink = domQuery('div[data-entry-id=messageSubscriptionCorrelationKey] a', container);
+
+      // then
+      expect(documentationLink).to.exist;
+      expect(documentationLink.title).to.equal('Receive task documentation');
+    }));
+
   });
 
 });

--- a/test/spec/provider/zeebe/TaskDefinitionProps.bpmn
+++ b/test/spec/provider/zeebe/TaskDefinitionProps.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0k89tne" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_0k89tne" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.1">
   <bpmn:process id="Process_1" isExecutable="true">
     <bpmn:serviceTask id="ServiceTask_1" name="service task">
       <bpmn:extensionElements>
@@ -17,6 +17,8 @@
         <zeebe:taskDefinition type="foobar" />
       </bpmn:extensionElements>
     </bpmn:businessRuleTask>
+    <bpmn:scriptTask id="ScriptTask_1" name="ScriptTask_1" />
+    <bpmn:sendTask id="SendTask_1" name="SendTask_1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
@@ -37,6 +39,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_01ge5q8_di" bpmnElement="BusinessRuleTask_2">
         <dc:Bounds x="740" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0u7x1id_di" bpmnElement="ScriptTask_1">
+        <dc:Bounds x="810" y="390" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sypdy6_di" bpmnElement="SendTask_1">
+        <dc:Bounds x="660" y="390" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/provider/zeebe/TaskDefinitionProps.spec.js
+++ b/test/spec/provider/zeebe/TaskDefinitionProps.spec.js
@@ -217,6 +217,78 @@ describe('provider/zeebe - TaskDefinitionProps', function() {
       })
     );
 
+
+    it('should display correct documentation for ServiceTask', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ServiceTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const documentationLink = domQuery('div[data-entry-id=taskDefinitionType] a', container);
+
+      // then
+      expect(documentationLink).to.exist;
+      expect(documentationLink.title).to.equal('Service task documentation');
+    }));
+
+
+    it('should display correct documentation for BusinessRuleTask', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('BusinessRuleTask_2');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const documentationLink = domQuery('div[data-entry-id=taskDefinitionType] a', container);
+
+      // then
+      expect(documentationLink).to.exist;
+      expect(documentationLink.title).to.equal('Business rule task documentation');
+    }));
+
+
+    it('should display correct documentation for ScriptTask', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('ScriptTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const documentationLink = domQuery('div[data-entry-id=taskDefinitionType] a', container);
+
+      // then
+      expect(documentationLink).to.exist;
+      expect(documentationLink.title).to.equal('Script task documentation');
+    }));
+
+
+    it('should display correct documentation for SendTask', inject(async function(elementRegistry, selection) {
+
+      // given
+      const serviceTask = elementRegistry.get('SendTask_1');
+
+      await act(() => {
+        selection.select(serviceTask);
+      });
+
+      // when
+      const documentationLink = domQuery('div[data-entry-id=taskDefinitionType] a', container);
+
+      // then
+      expect(documentationLink).to.exist;
+      expect(documentationLink.title).to.equal('Send task documentation');
+    }));
+
   });
 
 


### PR DESCRIPTION
* This is a quick fix as we agreed to better guide the users when
  starting with Cloud
* There are several follow-ups to better implement this:
  1. implement bpmn-io/properties-panel#119 and migrate the links @MaxTru 
  2. develop a concept how to better display help links (e.g., provide
     ability to have documentation for entire sections) @andreasgeier 
  3. better aling docs with propPanel links (DevRel?)


Screenshots of changes:
![Screenshot_20211124_161830](https://user-images.githubusercontent.com/42800119/143265275-a78139f5-ecde-468b-ae2f-211258af7bf9.png)

![Screenshot_20211124_161857](https://user-images.githubusercontent.com/42800119/143265340-3825c294-9095-4652-aa38-3a842a4b61f9.png)

![Screenshot_20211124_161918](https://user-images.githubusercontent.com/42800119/143265395-5c6bccbc-66b4-4a96-8c90-883cfb52163f.png)

![Screenshot_20211124_161948](https://user-images.githubusercontent.com/42800119/143265512-ef23e00b-c854-4c7c-b852-7b1472d23c61.png)

![Screenshot_20211124_162027](https://user-images.githubusercontent.com/42800119/143265644-437b9f29-48ea-4b14-af23-5f19bbe064bb.png)

![Screenshot_20211124_162048](https://user-images.githubusercontent.com/42800119/143265689-2baf2a60-e4b8-43c3-a26c-1ad4847c8efe.png)

![Screenshot_20211124_162107](https://user-images.githubusercontent.com/42800119/143265754-ab832804-b9ca-4f23-abf2-6eda89bb38d8.png)

![Screenshot_20211124_162122](https://user-images.githubusercontent.com/42800119/143265789-ee45e94f-2bc2-457f-b0cb-2c3fd394e0cf.png)


<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
